### PR TITLE
Refactor LED display into reusable components

### DIFF
--- a/NammaMeter/LEDDisplayComponents.swift
+++ b/NammaMeter/LEDDisplayComponents.swift
@@ -1,0 +1,507 @@
+import SwiftUI
+
+// MARK: - LED Color Scheme
+
+/// Defines the active and dim colors for LED displays.
+/// Use presets for common LED colors or create custom schemes.
+struct LEDColorScheme: Equatable, Sendable {
+    let active: Color
+    let dim: Color
+
+    // Common LED color presets
+    static let red = LEDColorScheme(
+        active: Color(red: 1.0, green: 0.2, blue: 0.12),
+        dim: Color(red: 0.12, green: 0.06, blue: 0.06)
+    )
+
+    static let green = LEDColorScheme(
+        active: Color(red: 0.2, green: 1.0, blue: 0.25),
+        dim: Color(red: 0.06, green: 0.12, blue: 0.07)
+    )
+
+    static let amber = LEDColorScheme(
+        active: Color(red: 1.0, green: 0.65, blue: 0.0),
+        dim: Color(red: 0.12, green: 0.08, blue: 0.04)
+    )
+
+    static let blue = LEDColorScheme(
+        active: Color(red: 0.2, green: 0.5, blue: 1.0),
+        dim: Color(red: 0.06, green: 0.08, blue: 0.12)
+    )
+
+    static let white = LEDColorScheme(
+        active: Color(red: 1.0, green: 1.0, blue: 0.95),
+        dim: Color(red: 0.12, green: 0.12, blue: 0.11)
+    )
+}
+
+// MARK: - LED Segment Shape
+
+/// Custom shape for LED segments with pointed ends for authentic appearance.
+struct LEDSegmentShape: Shape {
+    let isHorizontal: Bool
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+
+        if isHorizontal {
+            let pointOffset = rect.height * 0.5
+            path.move(to: CGPoint(x: pointOffset, y: rect.midY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX - pointOffset, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+            path.addLine(to: CGPoint(x: rect.maxX - pointOffset, y: rect.maxY))
+            path.addLine(to: CGPoint(x: pointOffset, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.midY))
+        } else {
+            let pointOffset = rect.width * 0.5
+            path.move(to: CGPoint(x: rect.midX, y: pointOffset))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY - pointOffset))
+            path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - pointOffset))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.midX, y: pointOffset))
+        }
+
+        path.closeSubpath()
+        return path
+    }
+}
+
+// MARK: - 7-Segment Digit
+
+/// A single 7-segment LED digit display.
+/// Supports digits 0-9 and select characters (F, o, r, H, I, E, n, t, L, P, A, b, c, d, U).
+struct LED7SegmentDigit: View {
+    let value: LED7SegmentValue
+    let height: CGFloat
+    var colorScheme: LEDColorScheme = .red
+    var isSmall: Bool = false
+
+    /// Segment order: [a, b, c, d, e, f, g]
+    /// a=top, b=top-right, c=bottom-right, d=bottom, e=bottom-left, f=top-left, g=middle
+    private static let segmentMap: [Int: [Bool]] = [
+        0: [true, true, true, true, true, true, false],
+        1: [false, true, true, false, false, false, false],
+        2: [true, true, false, true, true, false, true],
+        3: [true, true, true, true, false, false, true],
+        4: [false, true, true, false, false, true, true],
+        5: [true, false, true, true, false, true, true],
+        6: [true, false, true, true, true, true, true],
+        7: [true, true, true, false, false, false, false],
+        8: [true, true, true, true, true, true, true],
+        9: [true, true, true, true, false, true, true]
+    ]
+
+    private static let letterMap: [Character: [Bool]] = [
+        "F": [true, false, false, false, true, true, true],
+        "o": [false, false, true, true, true, false, true],
+        "r": [false, false, false, false, true, false, true],
+        "H": [false, true, true, false, true, true, true],
+        "I": [false, true, true, false, false, false, false],
+        "E": [true, false, false, true, true, true, true],
+        "n": [false, false, true, false, true, false, true],
+        "t": [false, false, false, true, true, true, true],
+        "L": [false, false, false, true, true, true, false],
+        "P": [true, true, false, false, true, true, true],
+        "A": [true, true, true, false, true, true, true],
+        "b": [false, false, true, true, true, true, true],
+        "c": [false, false, false, true, true, false, true],
+        "d": [false, true, true, true, true, false, true],
+        "U": [false, true, true, true, true, true, false],
+        "-": [false, false, false, false, false, false, true]
+    ]
+
+    private var segments: [Bool] {
+        switch value {
+        case .digit(let d):
+            return Self.segmentMap[d] ?? Array(repeating: false, count: 7)
+        case .character(let c):
+            return Self.letterMap[c] ?? Array(repeating: false, count: 7)
+        case .blank:
+            return Array(repeating: false, count: 7)
+        }
+    }
+
+    var body: some View {
+        let width = height * 0.6
+        let segmentThickness = height * (isSmall ? 0.1 : 0.12)
+        let segmentLength = height * 0.38
+
+        ZStack {
+            // Background for digit area
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Color.black.opacity(0.3))
+                .frame(width: width, height: height)
+
+            // Segment a (top horizontal)
+            segmentView(index: 0, isHorizontal: true, length: segmentLength, thickness: segmentThickness)
+                .offset(y: -height * 0.38)
+
+            // Segment b (top right vertical)
+            segmentView(index: 1, isHorizontal: false, length: segmentLength * 0.85, thickness: segmentThickness)
+                .offset(x: width * 0.28, y: -height * 0.18)
+
+            // Segment c (bottom right vertical)
+            segmentView(index: 2, isHorizontal: false, length: segmentLength * 0.85, thickness: segmentThickness)
+                .offset(x: width * 0.28, y: height * 0.18)
+
+            // Segment d (bottom horizontal)
+            segmentView(index: 3, isHorizontal: true, length: segmentLength, thickness: segmentThickness)
+                .offset(y: height * 0.38)
+
+            // Segment e (bottom left vertical)
+            segmentView(index: 4, isHorizontal: false, length: segmentLength * 0.85, thickness: segmentThickness)
+                .offset(x: -width * 0.28, y: height * 0.18)
+
+            // Segment f (top left vertical)
+            segmentView(index: 5, isHorizontal: false, length: segmentLength * 0.85, thickness: segmentThickness)
+                .offset(x: -width * 0.28, y: -height * 0.18)
+
+            // Segment g (middle horizontal)
+            segmentView(index: 6, isHorizontal: true, length: segmentLength, thickness: segmentThickness)
+        }
+        .frame(width: width, height: height)
+    }
+
+    @ViewBuilder
+    private func segmentView(index: Int, isHorizontal: Bool, length: CGFloat, thickness: CGFloat) -> some View {
+        let isActive = segments[index]
+        LEDSegmentShape(isHorizontal: isHorizontal)
+            .fill(isActive ? colorScheme.active : colorScheme.dim)
+            .frame(width: isHorizontal ? length : thickness, height: isHorizontal ? thickness : length)
+            .shadow(color: isActive ? colorScheme.active.opacity(0.7) : .clear, radius: isActive ? 4 : 0)
+    }
+}
+
+/// Value to display in a 7-segment digit
+enum LED7SegmentValue: Equatable, Sendable {
+    case digit(Int)
+    case character(Character)
+    case blank
+}
+
+// MARK: - LED Decimal Point
+
+/// A single LED decimal point or dot indicator.
+struct LEDDecimalPoint: View {
+    var isActive: Bool = true
+    var colorScheme: LEDColorScheme = .red
+    let size: CGFloat
+
+    var body: some View {
+        Circle()
+            .fill(isActive ? colorScheme.active : colorScheme.dim)
+            .frame(width: size, height: size)
+            .shadow(color: isActive ? colorScheme.active.opacity(0.8) : .clear, radius: isActive ? 4 : 0)
+    }
+}
+
+// MARK: - LED Colon (for time displays)
+
+/// A colon separator for time displays (two stacked dots).
+struct LEDColon: View {
+    var isActive: Bool = true
+    var colorScheme: LEDColorScheme = .red
+    let height: CGFloat
+
+    var body: some View {
+        let dotSize = height * 0.1
+        VStack(spacing: height * 0.15) {
+            Circle()
+                .fill(isActive ? colorScheme.active : colorScheme.dim)
+                .frame(width: dotSize, height: dotSize)
+            Circle()
+                .fill(isActive ? colorScheme.active : colorScheme.dim)
+                .frame(width: dotSize, height: dotSize)
+        }
+        .shadow(color: isActive ? colorScheme.active.opacity(0.6) : .clear, radius: isActive ? 2 : 0)
+    }
+}
+
+// MARK: - LED Digit Group
+
+/// A group of 7-segment digits for displaying numbers or text.
+/// Supports configurable digit count, decimal position, colon separator, and leading zero blanking.
+struct LEDDigitGroup: View {
+    let digitCount: Int
+    let height: CGFloat
+    var colorScheme: LEDColorScheme = .red
+    var isSmall: Bool = false
+    var spacing: CGFloat? = nil
+
+    /// Position of decimal point (0-indexed from left). nil = no decimal.
+    var decimalPosition: Int? = nil
+
+    /// Position of colon (0-indexed from left, appears after this digit). nil = no colon.
+    var colonPosition: Int? = nil
+
+    /// The values to display (digit, character, or blank for each position)
+    let values: [LED7SegmentValue]
+
+    private var effectiveSpacing: CGFloat {
+        spacing ?? (height * (isSmall ? 0.08 : 0.12))
+    }
+
+    var body: some View {
+        HStack(spacing: effectiveSpacing) {
+            ForEach(0..<digitCount, id: \.self) { index in
+                let value = index < values.count ? values[index] : .blank
+
+                LED7SegmentDigit(
+                    value: value,
+                    height: height,
+                    colorScheme: colorScheme,
+                    isSmall: isSmall
+                )
+
+                // Colon after this digit?
+                if colonPosition == index {
+                    LEDColon(
+                        isActive: !values.allSatisfy { $0 == .blank },
+                        colorScheme: colorScheme,
+                        height: height
+                    )
+                }
+
+                // Decimal after this digit?
+                if decimalPosition == index {
+                    LEDDecimalPoint(
+                        isActive: !values.allSatisfy { $0 == .blank },
+                        colorScheme: colorScheme,
+                        size: height * (isSmall ? 0.08 : 0.12)
+                    )
+                    .offset(y: height * (isSmall ? 0.35 : 0.4))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - LED Digit Group Helpers
+
+extension LEDDigitGroup {
+    /// Creates a digit group displaying an integer with optional leading zero blanking.
+    static func forInteger(
+        _ value: Int?,
+        digitCount: Int,
+        height: CGFloat,
+        colorScheme: LEDColorScheme = .red,
+        isSmall: Bool = false,
+        leadingZeroBlanking: Bool = true,
+        decimalPosition: Int? = nil
+    ) -> LEDDigitGroup {
+        var values: [LED7SegmentValue] = []
+
+        if let value = value {
+            var remaining = value
+            var digits: [Int] = []
+
+            // Extract digits from right to left
+            for _ in 0..<digitCount {
+                digits.insert(remaining % 10, at: 0)
+                remaining /= 10
+            }
+
+            // Apply leading zero blanking
+            var foundNonZero = false
+            for (index, digit) in digits.enumerated() {
+                if digit != 0 {
+                    foundNonZero = true
+                }
+                // Keep last digit even if zero, blank leading zeros
+                let isLastDigit = index == digits.count - 1
+                let shouldBlank = leadingZeroBlanking && !foundNonZero && !isLastDigit
+                values.append(shouldBlank ? .blank : .digit(digit))
+            }
+        } else {
+            values = Array(repeating: .blank, count: digitCount)
+        }
+
+        return LEDDigitGroup(
+            digitCount: digitCount,
+            height: height,
+            colorScheme: colorScheme,
+            isSmall: isSmall,
+            decimalPosition: decimalPosition,
+            values: values
+        )
+    }
+
+    /// Creates a digit group displaying text characters.
+    static func forText(
+        _ text: String,
+        digitCount: Int,
+        height: CGFloat,
+        colorScheme: LEDColorScheme = .red,
+        isSmall: Bool = false,
+        alignment: HorizontalAlignment = .center
+    ) -> LEDDigitGroup {
+        var values: [LED7SegmentValue] = Array(repeating: .blank, count: digitCount)
+        let chars = Array(text)
+
+        let startIndex: Int
+        switch alignment {
+        case .leading:
+            startIndex = 0
+        case .trailing:
+            startIndex = max(0, digitCount - chars.count)
+        default: // center
+            startIndex = max(0, (digitCount - chars.count) / 2)
+        }
+
+        for (i, char) in chars.enumerated() {
+            let targetIndex = startIndex + i
+            if targetIndex < digitCount {
+                values[targetIndex] = .character(char)
+            }
+        }
+
+        return LEDDigitGroup(
+            digitCount: digitCount,
+            height: height,
+            colorScheme: colorScheme,
+            isSmall: isSmall,
+            values: values
+        )
+    }
+}
+
+// MARK: - LED Panel
+
+/// A panel containing LED digit groups with optional labels.
+/// Used to create structured displays like fare, time, or distance readouts.
+struct LEDPanel<Content: View>: View {
+    let width: CGFloat
+    let height: CGFloat
+    var leftLabel: String? = nil
+    var rightLabel: String? = nil
+    var labelColor: Color = Color(red: 0.75, green: 0.75, blue: 0.72)
+    let content: () -> Content
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if let left = leftLabel {
+                Text(left)
+                    .font(.system(size: height * 0.22, weight: .semibold, design: .rounded))
+                    .foregroundStyle(labelColor)
+                    .frame(width: width * 0.15, alignment: .leading)
+            }
+
+            Spacer()
+
+            content()
+
+            Spacer()
+
+            if let right = rightLabel {
+                Text(right)
+                    .font(.system(size: height * 0.22, weight: .semibold, design: .rounded))
+                    .foregroundStyle(labelColor)
+                    .frame(width: width * 0.1, alignment: .trailing)
+            }
+        }
+        .frame(width: width, height: height)
+    }
+}
+
+// MARK: - LED Status Indicator
+
+/// A single LED status indicator dot with label.
+struct LEDStatusIndicator: View {
+    let label: String
+    let isActive: Bool
+    let height: CGFloat
+    var colorScheme: LEDColorScheme = .red
+    var labelColor: Color = Color(red: 0.6, green: 0.6, blue: 0.58)
+
+    var body: some View {
+        VStack(spacing: height * 0.08) {
+            Circle()
+                .fill(isActive ? colorScheme.active : colorScheme.dim)
+                .frame(width: height * 0.22, height: height * 0.22)
+                .overlay(
+                    Circle()
+                        .stroke(Color.black.opacity(0.5), lineWidth: 1)
+                )
+                .shadow(color: isActive ? colorScheme.active.opacity(0.8) : .clear, radius: isActive ? 6 : 0)
+
+            Text(label)
+                .font(.system(size: height * 0.14, weight: .medium, design: .rounded))
+                .foregroundStyle(labelColor)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .minimumScaleFactor(0.8)
+        }
+        .frame(width: height * 0.6)
+    }
+}
+
+// MARK: - LED Display Container
+
+/// A container for LED panels with standard dark background and bezel.
+struct LEDDisplayContainer<Content: View>: View {
+    let width: CGFloat
+    let height: CGFloat
+    var backgroundColor: Color = Color(red: 0.03, green: 0.04, blue: 0.05)
+    var bezelColor: Color = Color(red: 0.12, green: 0.12, blue: 0.14)
+    var cornerRadius: CGFloat? = nil
+    var bezelWidth: CGFloat = 3
+    let content: () -> Content
+
+    var body: some View {
+        let radius = cornerRadius ?? (width * 0.03)
+
+        RoundedRectangle(cornerRadius: radius, style: .continuous)
+            .fill(backgroundColor)
+            .overlay(
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .stroke(bezelColor, lineWidth: bezelWidth)
+            )
+            .frame(width: width, height: height)
+            .overlay(content())
+    }
+}
+
+// MARK: - Previews
+
+#Preview("LED Colors") {
+    VStack(spacing: 20) {
+        HStack(spacing: 20) {
+            LED7SegmentDigit(value: .digit(8), height: 60, colorScheme: .red)
+            LED7SegmentDigit(value: .digit(8), height: 60, colorScheme: .green)
+            LED7SegmentDigit(value: .digit(8), height: 60, colorScheme: .amber)
+            LED7SegmentDigit(value: .digit(8), height: 60, colorScheme: .blue)
+        }
+
+        HStack(spacing: 20) {
+            LEDDigitGroup.forInteger(123, digitCount: 4, height: 50, colorScheme: .red)
+            LEDDigitGroup.forInteger(45, digitCount: 4, height: 50, colorScheme: .green, leadingZeroBlanking: true)
+        }
+
+        LEDDigitGroup.forText("HI", digitCount: 4, height: 50, colorScheme: .amber)
+    }
+    .padding()
+    .background(Color.black)
+}
+
+#Preview("Digit Group with Decimal") {
+    VStack(spacing: 20) {
+        // Fare display: 123.45
+        HStack(spacing: 8) {
+            LEDDigitGroup.forInteger(123, digitCount: 3, height: 60, decimalPosition: 2)
+            LEDDigitGroup.forInteger(45, digitCount: 2, height: 60, leadingZeroBlanking: false)
+        }
+
+        // Time display: 12:34
+        LEDDigitGroup(
+            digitCount: 4,
+            height: 50,
+            colonPosition: 1,
+            values: [.digit(1), .digit(2), .digit(3), .digit(4)]
+        )
+    }
+    .padding()
+    .background(Color.black)
+}

--- a/NammaMeter/SuperElectronicMeterView.swift
+++ b/NammaMeter/SuperElectronicMeterView.swift
@@ -247,66 +247,81 @@ struct SuperElectronicFareRow: View {
 struct FareDigitsDisplay: View {
   let fare: Double
   let digitHeight: CGFloat
+  var colorScheme: LEDColorScheme = .red
 
   var body: some View {
     let totalPaise = max(0, Int((fare * 100).rounded()))
     let rupees = totalPaise / 100
     let paise = totalPaise % 100
 
-    // 3 digits for rupees (leading zeros blank), 2 for paise
-    let r2 = (rupees / 100) % 10  // hundreds
-    let r1 = (rupees / 10) % 10   // tens
-    let r0 = rupees % 10          // ones
-    let p1 = paise / 10           // paise tens
-    let p0 = paise % 10           // paise ones
+    // Build rupee values with leading zero blanking
+    let r2 = (rupees / 100) % 10
+    let r1 = (rupees / 10) % 10
+    let r0 = rupees % 10
+    let rupeeValues: [LED7SegmentValue] = [
+      r2 > 0 ? .digit(r2) : .blank,
+      (r2 > 0 || r1 > 0) ? .digit(r1) : .blank,
+      .digit(r0)
+    ]
+
+    // Paise values (always show both)
+    let p1 = paise / 10
+    let p0 = paise % 10
+    let paiseValues: [LED7SegmentValue] = [.digit(p1), .digit(p0)]
 
     HStack(spacing: digitHeight * 0.12) {
-      // Rupees digits (leading zeros blank)
-      SevenSegmentDigit(digit: r2 > 0 ? r2 : nil, height: digitHeight)
-      SevenSegmentDigit(digit: (r2 > 0 || r1 > 0) ? r1 : nil, height: digitHeight)
-      SevenSegmentDigit(digit: r0, height: digitHeight)
+      LEDDigitGroup(
+        digitCount: 3,
+        height: digitHeight,
+        colorScheme: colorScheme,
+        decimalPosition: 2,
+        values: rupeeValues
+      )
 
-      // Decimal point
-      Circle()
-        .fill(LEDColors.activeRed)
-        .frame(width: digitHeight * 0.12, height: digitHeight * 0.12)
-        .shadow(color: LEDColors.activeRed.opacity(0.8), radius: 4)
-        .offset(y: digitHeight * 0.4)
-
-      // Paise digits (always show both)
-      SevenSegmentDigit(digit: p1, height: digitHeight)
-      SevenSegmentDigit(digit: p0, height: digitHeight)
+      LEDDigitGroup(
+        digitCount: 2,
+        height: digitHeight,
+        colorScheme: colorScheme,
+        values: paiseValues
+      )
     }
   }
 }
 
 struct ForHireFareDisplay: View {
   let digitHeight: CGFloat
+  var colorScheme: LEDColorScheme = .red
 
   var body: some View {
-    // Show "For" in middle 3 positions (positions 1, 2, 3 of 5)
-    // Position 0: blank, Position 1: F, Position 2: o, Position 3: r, Position 4: blank
+    // Show "For" across positions with dim decimal
+    let values: [LED7SegmentValue] = [
+      .blank,
+      .character("F"),
+      .character("o"),
+      .character("r"),
+      .blank
+    ]
+
     HStack(spacing: digitHeight * 0.12) {
-      // Position 0: blank (hundreds rupees)
-      SevenSegmentDigit(digit: nil, height: digitHeight)
+      // First 3 digits (blank, F, o) with dim decimal after
+      LEDDigitGroup(
+        digitCount: 3,
+        height: digitHeight,
+        colorScheme: colorScheme,
+        values: Array(values[0...2])
+      )
 
-      // Position 1: F (tens rupees)
-      SevenSegmentDigit(digit: nil, height: digitHeight, character: "F")
-
-      // Position 2: o (ones rupees)
-      SevenSegmentDigit(digit: nil, height: digitHeight, character: "o")
-
-      // Decimal point - dim
-      Circle()
-        .fill(LEDColors.dimRed)
-        .frame(width: digitHeight * 0.12, height: digitHeight * 0.12)
+      // Dim decimal point
+      LEDDecimalPoint(isActive: false, colorScheme: colorScheme, size: digitHeight * 0.12)
         .offset(y: digitHeight * 0.4)
 
-      // Position 3: r (tens paise)
-      SevenSegmentDigit(digit: nil, height: digitHeight, character: "r")
-
-      // Position 4: blank (ones paise)
-      SevenSegmentDigit(digit: nil, height: digitHeight)
+      // Last 2 digits (r, blank)
+      LEDDigitGroup(
+        digitCount: 2,
+        height: digitHeight,
+        colorScheme: colorScheme,
+        values: Array(values[3...4])
+      )
     }
   }
 }
@@ -361,53 +376,47 @@ struct WaitTimeDisplay: View {
   let digitHeight: CGFloat
   var showBlank: Bool = false
   var showForHire: Bool = false
+  var colorScheme: LEDColorScheme = .red
+
+  private var displayValues: (values: [LED7SegmentValue], colonActive: Bool) {
+    if showForHire {
+      return ([.blank, .blank, .character("H"), .character("I")], false)
+    } else if showBlank {
+      return ([.blank, .blank, .blank, .blank], false)
+    } else {
+      let totalSeconds = Int(duration)
+      let minutes = (totalSeconds / 60) % 100
+      let seconds = totalSeconds % 60
+      return ([
+        .digit(minutes / 10),
+        .digit(minutes % 10),
+        .digit(seconds / 10),
+        .digit(seconds % 10)
+      ], true)
+    }
+  }
 
   var body: some View {
-    let totalSeconds = Int(duration)
-    let minutes = (totalSeconds / 60) % 100
-    let seconds = totalSeconds % 60
-
-    let m1 = showBlank ? nil : minutes / 10
-    let m0 = showBlank ? nil : minutes % 10
-    let s1 = showBlank ? nil : seconds / 10
-    let s0 = showBlank ? nil : seconds % 10
+    let (values, colonActive) = displayValues
 
     HStack(spacing: digitHeight * 0.08) {
-      if showForHire {
-        // Show blank in first two positions, "HI" in last two
-        SevenSegmentDigit(digit: nil, height: digitHeight, isSmall: true)
-        SevenSegmentDigit(digit: nil, height: digitHeight, isSmall: true)
+      LEDDigitGroup(
+        digitCount: 2,
+        height: digitHeight,
+        colorScheme: colorScheme,
+        isSmall: true,
+        values: Array(values[0...1])
+      )
 
-        // Colon - dim
-        VStack(spacing: digitHeight * 0.15) {
-          Circle()
-            .fill(LEDColors.dimRed)
-            .frame(width: digitHeight * 0.1, height: digitHeight * 0.1)
-          Circle()
-            .fill(LEDColors.dimRed)
-            .frame(width: digitHeight * 0.1, height: digitHeight * 0.1)
-        }
+      LEDColon(isActive: colonActive, colorScheme: colorScheme, height: digitHeight)
 
-        SevenSegmentDigit(digit: nil, height: digitHeight, isSmall: true, character: "H")
-        SevenSegmentDigit(digit: nil, height: digitHeight, isSmall: true, character: "I")
-      } else {
-        SevenSegmentDigit(digit: m1, height: digitHeight, isSmall: true)
-        SevenSegmentDigit(digit: m0, height: digitHeight, isSmall: true)
-
-        // Colon - dim when blank
-        VStack(spacing: digitHeight * 0.15) {
-          Circle()
-            .fill(showBlank ? LEDColors.dimRed : LEDColors.activeRed)
-            .frame(width: digitHeight * 0.1, height: digitHeight * 0.1)
-          Circle()
-            .fill(showBlank ? LEDColors.dimRed : LEDColors.activeRed)
-            .frame(width: digitHeight * 0.1, height: digitHeight * 0.1)
-        }
-        .shadow(color: showBlank ? .clear : LEDColors.activeRed.opacity(0.6), radius: showBlank ? 0 : 2)
-
-        SevenSegmentDigit(digit: s1, height: digitHeight, isSmall: true)
-        SevenSegmentDigit(digit: s0, height: digitHeight, isSmall: true)
-      }
+      LEDDigitGroup(
+        digitCount: 2,
+        height: digitHeight,
+        colorScheme: colorScheme,
+        isSmall: true,
+        values: Array(values[2...3])
+      )
     }
   }
 }
@@ -417,49 +426,43 @@ struct DistanceDisplay: View {
   let digitHeight: CGFloat
   var showBlank: Bool = false
   var showForHire: Bool = false
+  var colorScheme: LEDColorScheme = .red
+
+  private var displayValues: (integerValues: [LED7SegmentValue], decimalValue: LED7SegmentValue, decimalActive: Bool) {
+    if showForHire {
+      return ([.character("r"), .character("E"), .blank], .blank, false)
+    } else if showBlank {
+      return ([.blank, .blank, .blank], .blank, false)
+    } else {
+      let totalTenths = Int((distanceKm * 10).rounded()) % 10000
+      let d2raw = (totalTenths / 1000) % 10
+      let d1raw = (totalTenths / 100) % 10
+      let d0raw = (totalTenths / 10) % 10
+      let decimalRaw = totalTenths % 10
+      return ([
+        d2raw > 0 ? .digit(d2raw) : .blank,
+        (d2raw > 0 || d1raw > 0) ? .digit(d1raw) : .blank,
+        .digit(d0raw)
+      ], .digit(decimalRaw), true)
+    }
+  }
 
   var body: some View {
-    // Show distance as 000.0 format (3 integer + 1 decimal)
-    let totalTenths = Int((distanceKm * 10).rounded()) % 10000
-    let d2raw = (totalTenths / 1000) % 10  // hundreds of km
-    let d1raw = (totalTenths / 100) % 10   // tens of km
-    let d0raw = (totalTenths / 10) % 10    // ones of km
-    let decimalRaw = totalTenths % 10       // tenths of km
-
-    // Leading zeros blank for d2 and d1
-    let d2: Int? = showBlank ? nil : (d2raw > 0 ? d2raw : nil)
-    let d1: Int? = showBlank ? nil : ((d2raw > 0 || d1raw > 0) ? d1raw : nil)
-    let d0: Int? = showBlank ? nil : d0raw
-    let decimal: Int? = showBlank ? nil : decimalRaw
+    let (integerValues, decimalValue, decimalActive) = displayValues
 
     HStack(spacing: digitHeight * 0.08) {
-      if showForHire {
-        // Show "rE" in first two positions, rest blank
-        SevenSegmentDigit(digit: nil, height: digitHeight, isSmall: true, character: "r")
-        SevenSegmentDigit(digit: nil, height: digitHeight, isSmall: true, character: "E")
-        SevenSegmentDigit(digit: nil, height: digitHeight, isSmall: true)
+      LEDDigitGroup(
+        digitCount: 3,
+        height: digitHeight,
+        colorScheme: colorScheme,
+        isSmall: true,
+        values: integerValues
+      )
 
-        // Decimal point - dim
-        Circle()
-          .fill(LEDColors.dimRed)
-          .frame(width: digitHeight * 0.08, height: digitHeight * 0.08)
-          .offset(y: digitHeight * 0.35)
+      LEDDecimalPoint(isActive: decimalActive, colorScheme: colorScheme, size: digitHeight * 0.08)
+        .offset(y: digitHeight * 0.35)
 
-        SevenSegmentDigit(digit: nil, height: digitHeight, isSmall: true)
-      } else {
-        SevenSegmentDigit(digit: d2, height: digitHeight, isSmall: true)
-        SevenSegmentDigit(digit: d1, height: digitHeight, isSmall: true)
-        SevenSegmentDigit(digit: d0, height: digitHeight, isSmall: true)
-
-        // Decimal point - dim when blank
-        Circle()
-          .fill(showBlank ? LEDColors.dimRed : LEDColors.activeRed)
-          .frame(width: digitHeight * 0.08, height: digitHeight * 0.08)
-          .shadow(color: showBlank ? .clear : LEDColors.activeRed.opacity(0.6), radius: showBlank ? 0 : 2)
-          .offset(y: digitHeight * 0.35)
-
-        SevenSegmentDigit(digit: decimal, height: digitHeight, isSmall: true)
-      }
+      LED7SegmentDigit(value: decimalValue, height: digitHeight, colorScheme: colorScheme, isSmall: true)
     }
   }
 }
@@ -532,38 +535,6 @@ struct SuperElectronicStatusBar: View {
   }
 }
 
-struct LEDStatusIndicator: View {
-  let label: String
-  let isActive: Bool
-  let height: CGFloat
-
-  private let activeColor = Color(red: 1.0, green: 0.2, blue: 0.15)
-  private let dimColor = Color(red: 0.15, green: 0.08, blue: 0.08)
-  private let labelColor = Color(red: 0.6, green: 0.6, blue: 0.58)
-
-  var body: some View {
-    VStack(spacing: height * 0.08) {
-      // LED dot
-      Circle()
-        .fill(isActive ? activeColor : dimColor)
-        .frame(width: height * 0.22, height: height * 0.22)
-        .overlay(
-          Circle()
-            .stroke(Color.black.opacity(0.5), lineWidth: 1)
-        )
-        .shadow(color: isActive ? activeColor.opacity(0.8) : .clear, radius: isActive ? 6 : 0)
-
-      // Label
-      Text(label)
-        .font(.system(size: height * 0.14, weight: .medium, design: .rounded))
-        .foregroundStyle(labelColor)
-        .multilineTextAlignment(.center)
-        .lineLimit(2)
-        .minimumScaleFactor(0.8)
-    }
-    .frame(width: height * 0.6)
-  }
-}
 
 // MARK: - Manufacturer Plate
 
@@ -613,149 +584,6 @@ struct SuperElectronicManufacturerPlate: View {
   }
 }
 
-// MARK: - Seven Segment Digit
-
-enum LEDColors {
-  static let activeRed = Color(red: 1.0, green: 0.2, blue: 0.12)
-  static let dimRed = Color(red: 0.12, green: 0.06, blue: 0.06)
-}
-
-struct SevenSegmentDigit: View {
-  let digit: Int?
-  let height: CGFloat
-  var isSmall: Bool = false
-  var character: Character? = nil
-
-  // Segment order: [a, b, c, d, e, f, g]
-  // a=top, b=top-right, c=bottom-right, d=bottom, e=bottom-left, f=top-left, g=middle
-  private let segmentMap: [Int: [Bool]] = [
-    0: [true, true, true, true, true, true, false],
-    1: [false, true, true, false, false, false, false],
-    2: [true, true, false, true, true, false, true],
-    3: [true, true, true, true, false, false, true],
-    4: [false, true, true, false, false, true, true],
-    5: [true, false, true, true, false, true, true],
-    6: [true, false, true, true, true, true, true],
-    7: [true, true, true, false, false, false, false],
-    8: [true, true, true, true, true, true, true],
-    9: [true, true, true, true, false, true, true]
-  ]
-
-  // Letter segment mappings for FOR HIRE display
-  private let letterMap: [Character: [Bool]] = [
-    "F": [true, false, false, false, true, true, true],   // a, f, g, e
-    "o": [false, false, true, true, true, false, true],   // g, e, c, d
-    "r": [false, false, false, false, true, false, true], // g, e
-    "H": [false, true, true, false, true, true, true],    // f, b, g, e, c
-    "I": [false, true, true, false, false, false, false], // b, c
-    "E": [true, false, false, true, true, true, true]     // a, f, g, e, d
-  ]
-
-  var body: some View {
-    let width = height * 0.6
-    let segmentThickness = height * (isSmall ? 0.1 : 0.12)
-    let segmentLength = height * 0.38
-
-    let segments: [Bool] = {
-      if let char = character {
-        return letterMap[char] ?? Array(repeating: false, count: 7)
-      } else if let d = digit {
-        return segmentMap[d] ?? Array(repeating: false, count: 7)
-      } else {
-        return Array(repeating: false, count: 7)
-      }
-    }()
-
-    ZStack {
-      // Background for digit area
-      RoundedRectangle(cornerRadius: 2)
-        .fill(Color.black.opacity(0.3))
-        .frame(width: width, height: height)
-
-      // Segment a (top horizontal)
-      SegmentShape(isHorizontal: true)
-        .fill(segments[0] ? LEDColors.activeRed : LEDColors.dimRed)
-        .frame(width: segmentLength, height: segmentThickness)
-        .shadow(color: segments[0] ? LEDColors.activeRed.opacity(0.7) : .clear, radius: segments[0] ? 4 : 0)
-        .offset(y: -height * 0.38)
-
-      // Segment b (top right vertical)
-      SegmentShape(isHorizontal: false)
-        .fill(segments[1] ? LEDColors.activeRed : LEDColors.dimRed)
-        .frame(width: segmentThickness, height: segmentLength * 0.85)
-        .shadow(color: segments[1] ? LEDColors.activeRed.opacity(0.7) : .clear, radius: segments[1] ? 4 : 0)
-        .offset(x: width * 0.28, y: -height * 0.18)
-
-      // Segment c (bottom right vertical)
-      SegmentShape(isHorizontal: false)
-        .fill(segments[2] ? LEDColors.activeRed : LEDColors.dimRed)
-        .frame(width: segmentThickness, height: segmentLength * 0.85)
-        .shadow(color: segments[2] ? LEDColors.activeRed.opacity(0.7) : .clear, radius: segments[2] ? 4 : 0)
-        .offset(x: width * 0.28, y: height * 0.18)
-
-      // Segment d (bottom horizontal)
-      SegmentShape(isHorizontal: true)
-        .fill(segments[3] ? LEDColors.activeRed : LEDColors.dimRed)
-        .frame(width: segmentLength, height: segmentThickness)
-        .shadow(color: segments[3] ? LEDColors.activeRed.opacity(0.7) : .clear, radius: segments[3] ? 4 : 0)
-        .offset(y: height * 0.38)
-
-      // Segment e (bottom left vertical)
-      SegmentShape(isHorizontal: false)
-        .fill(segments[4] ? LEDColors.activeRed : LEDColors.dimRed)
-        .frame(width: segmentThickness, height: segmentLength * 0.85)
-        .shadow(color: segments[4] ? LEDColors.activeRed.opacity(0.7) : .clear, radius: segments[4] ? 4 : 0)
-        .offset(x: -width * 0.28, y: height * 0.18)
-
-      // Segment f (top left vertical)
-      SegmentShape(isHorizontal: false)
-        .fill(segments[5] ? LEDColors.activeRed : LEDColors.dimRed)
-        .frame(width: segmentThickness, height: segmentLength * 0.85)
-        .shadow(color: segments[5] ? LEDColors.activeRed.opacity(0.7) : .clear, radius: segments[5] ? 4 : 0)
-        .offset(x: -width * 0.28, y: -height * 0.18)
-
-      // Segment g (middle horizontal)
-      SegmentShape(isHorizontal: true)
-        .fill(segments[6] ? LEDColors.activeRed : LEDColors.dimRed)
-        .frame(width: segmentLength, height: segmentThickness)
-        .shadow(color: segments[6] ? LEDColors.activeRed.opacity(0.7) : .clear, radius: segments[6] ? 4 : 0)
-    }
-    .frame(width: width, height: height)
-  }
-}
-
-struct SegmentShape: Shape {
-  let isHorizontal: Bool
-
-  func path(in rect: CGRect) -> Path {
-    var path = Path()
-
-    if isHorizontal {
-      // Horizontal segment with pointed ends
-      let pointOffset = rect.height * 0.5
-      path.move(to: CGPoint(x: pointOffset, y: rect.midY))
-      path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
-      path.addLine(to: CGPoint(x: rect.maxX - pointOffset, y: rect.minY))
-      path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
-      path.addLine(to: CGPoint(x: rect.maxX - pointOffset, y: rect.maxY))
-      path.addLine(to: CGPoint(x: pointOffset, y: rect.maxY))
-      path.addLine(to: CGPoint(x: rect.minX, y: rect.midY))
-    } else {
-      // Vertical segment with pointed ends
-      let pointOffset = rect.width * 0.5
-      path.move(to: CGPoint(x: rect.midX, y: pointOffset))
-      path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
-      path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY - pointOffset))
-      path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
-      path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - pointOffset))
-      path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
-      path.addLine(to: CGPoint(x: rect.midX, y: pointOffset))
-    }
-
-    path.closeSubpath()
-    return path
-  }
-}
 
 // MARK: - Preview
 


### PR DESCRIPTION
## Summary

Extracts common LED display logic into a new `LEDDisplayComponents.swift` file to enable creating different electronic meters with varying segment counts, panel layouts, and LED colors.

### New Reusable Components

| Component | Description |
|-----------|-------------|
| `LEDColorScheme` | Defines active/dim colors with presets: `.red`, `.green`, `.amber`, `.blue`, `.white` |
| `LED7SegmentDigit` | Single 7-segment digit supporting 0-9 and characters (F, o, r, H, I, E, n, t, L, P, A, b, c, d, U, -) |
| `LEDDigitGroup` | Configurable group of digits with optional decimal/colon positions and leading zero blanking |
| `LEDDecimalPoint` / `LEDColon` | Standalone separators with configurable colors |
| `LEDPanel` | Container view with left/right labels |
| `LEDDisplayContainer` | Container with dark background and bezel styling |
| `LEDStatusIndicator` | Status indicator dots with labels |

### Changes to SuperElectronicMeterView

- `FareDigitsDisplay` now uses `LEDDigitGroup` with `colorScheme` parameter
- `WaitTimeDisplay` uses `LEDDigitGroup` + `LEDColon`
- `DistanceDisplay` uses `LEDDigitGroup` + `LEDDecimalPoint`
- Removed duplicate components: `SevenSegmentDigit`, `SegmentShape`, `LEDColors`, `LEDStatusIndicator`

### Usage Examples

**Green speedometer:**
```swift
LEDDigitGroup.forInteger(
    speed, 
    digitCount: 3, 
    height: 60, 
    colorScheme: .green,
    leadingZeroBlanking: true
)
```

**Amber time display:**
```swift
LEDDigitGroup(
    digitCount: 4,
    height: 50,
    colorScheme: .amber,
    colonPosition: 1,
    values: [.digit(1), .digit(2), .digit(3), .digit(4)]
)
```

## Test plan

- [x] Build succeeds without errors
- [x] SuperElectronicMeter displays correctly in all states (FOR HIRE, HIRED, STOP)
- [x] Fare display shows correct digits with leading zero blanking
- [x] Wait time display shows MM:SS format with colon
- [x] Distance display shows 000.0 format with decimal point
- [x] Status indicators light up correctly for each state
- [x] Preview in Xcode shows expected LED colors and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)