### PR TITLE
Fix location update config and Always permission flow

### DIFF
--- a/NammaMeter/MeterStore.swift
+++ b/NammaMeter/MeterStore.swift
@@ -32,7 +32,7 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
 
   @ObservationIgnored private let locationManager: CLLocationManager
   @ObservationIgnored private var tickTask: Task<Void, Never>?
-  @ObservationIgnored private var locationUpdatesTask: Task<Void, Never>?
+  @ObservationIgnored private var isUpdatingLocation = false
   @ObservationIgnored private let clock = ContinuousClock()
   @ObservationIgnored private var startDate: Date?
   @ObservationIgnored private var lastLocation: CLLocation?
@@ -54,7 +54,14 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
   }
 
   func requestAuthorization() {
-    locationManager.requestWhenInUseAuthorization()
+    if authorizationStatus == .notDetermined {
+      locationManager.requestWhenInUseAuthorization()
+    }
+  }
+
+  func requestAlwaysAuthorization() {
+    guard authorizationStatus == .authorizedWhenInUse else { return }
+    locationManager.requestAlwaysAuthorization()
   }
 
   func startTrip(settings: MeterSettings) {
@@ -78,9 +85,11 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
     lastLocation = nil
     locationError = nil
 
+    authorizationStatus = locationManager.authorizationStatus
     requestAuthorization()
-    locationManager.requestAlwaysAuthorization()
-    startLocationUpdates()
+    if isAuthorizedForLocationUpdates {
+      startLocationUpdates()
+    }
     updateBackgroundLocationState()
     startTicking()
   }
@@ -136,24 +145,15 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
   }
 
   private func startLocationUpdates() {
-    locationUpdatesTask?.cancel()
-    locationUpdatesTask = Task { @MainActor [weak self] in
-      guard let self else { return }
-      do {
-        for try await update in CLLocationUpdate.liveUpdates() {
-          if Task.isCancelled { break }
-          guard let location = update.location else { continue }
-          self.handleLocation(location)
-        }
-      } catch {
-        locationError = error.localizedDescription
-      }
-    }
+    guard !isUpdatingLocation else { return }
+    isUpdatingLocation = true
+    locationManager.startUpdatingLocation()
   }
 
   private func stopLocationUpdates() {
-    locationUpdatesTask?.cancel()
-    locationUpdatesTask = nil
+    guard isUpdatingLocation else { return }
+    isUpdatingLocation = false
+    locationManager.stopUpdatingLocation()
   }
 
   private func tick() {
@@ -181,12 +181,22 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
   func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
     authorizationStatus = manager.authorizationStatus
     if isOnTrip {
+      if isAuthorizedForLocationUpdates {
+        startLocationUpdates()
+      } else {
+        stopLocationUpdates()
+      }
       updateBackgroundLocationState()
     }
   }
 
   func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
     locationError = error.localizedDescription
+  }
+
+  func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    guard let location = locations.last else { return }
+    handleLocation(location)
   }
 
   private func handleLocation(_ location: CLLocation) {
@@ -260,5 +270,14 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
   private var hasBackgroundLocationMode: Bool {
     guard let modes = Bundle.main.object(forInfoDictionaryKey: "UIBackgroundModes") as? [String] else { return false }
     return modes.contains("location")
+  }
+
+  private var isAuthorizedForLocationUpdates: Bool {
+    switch authorizationStatus {
+    case .authorizedAlways, .authorizedWhenInUse:
+      return true
+    default:
+      return false
+    }
   }
 }

--- a/NammaMeter/MeterView.swift
+++ b/NammaMeter/MeterView.swift
@@ -9,11 +9,13 @@ struct MeterView: View {
   @State private var meterStore = MeterStore()
   @Environment(\.openURL) private var openURL
   @State private var showLocationAlert = false
+  @State private var showAlwaysPrompt = false
   @State private var showMeterSettings = false
   @State private var pagerSelection = 0
   @State private var meterFaceStyle: MeterFaceStyle = .superMeter
   @State private var meterRenderMode: MeterRenderMode = .full
   @State private var digitWheelStyle: DigitWheelStyle = .disk
+  @State private var hasPromptedForAlways = false
 
   var body: some View {
     NavigationStack {
@@ -31,10 +33,21 @@ struct MeterView: View {
           showLocationAlert = true
         }
       }
+      .onChange(of: meterStore.isOnTrip) { _, isOnTrip in
+        if isOnTrip {
+          hasPromptedForAlways = false
+          evaluateAlwaysPrompt()
+        } else {
+          showAlwaysPrompt = false
+        }
+      }
       .onChange(of: meterStore.authorizationStatus) { _, newStatus in
         if newStatus == .denied || newStatus == .restricted {
           showLocationAlert = true
+        } else if newStatus == .authorizedAlways {
+          showAlwaysPrompt = false
         }
+        evaluateAlwaysPrompt()
       }
       .alert("Location access needed", isPresented: $showLocationAlert) {
         Button("Open Settings") {
@@ -45,6 +58,19 @@ struct MeterView: View {
         Button("Not Now", role: .cancel) { }
       } message: {
         Text("Enable location to track distance and replay routes.")
+      }
+      .alert("Enable background tracking", isPresented: $showAlwaysPrompt) {
+        Button("Enable Always") {
+          meterStore.requestAlwaysAuthorization()
+        }
+        Button("Open Settings") {
+          if let url = URL(string: UIApplication.openSettingsURLString) {
+            openURL(url)
+          }
+        }
+        Button("Not Now", role: .cancel) { }
+      } message: {
+        Text("Allow Always location access to keep tracking distance when the app is in the background.")
       }
       .sheet(isPresented: $showMeterSettings) {
         meterSettingsSheet
@@ -469,6 +495,14 @@ struct MeterView: View {
       get: { meterStore.conditions[keyPath: keyPath] },
       set: { meterStore.conditions[keyPath: keyPath] = $0 }
     )
+  }
+
+  private func evaluateAlwaysPrompt() {
+    guard meterStore.isOnTrip else { return }
+    guard meterStore.authorizationStatus == .authorizedWhenInUse else { return }
+    guard !hasPromptedForAlways else { return }
+    hasPromptedForAlways = true
+    showAlwaysPrompt = true
   }
 }
 


### PR DESCRIPTION
## Summary
- Use the configured CLLocationManager so desired accuracy and distance filter apply.
- Gate Always authorization behind an in-app prompt after When-In-Use is granted.
- Keep background updates enabled only with Always permission.

## Testing
- Manual (user-reported)

## Issues
- Fixes #8
- Fixes #10
