### PR TITLE
Remove rain/traffic modifiers from UI and settings

### DIFF
--- a/NammaMeter/MeterView.swift
+++ b/NammaMeter/MeterView.swift
@@ -242,16 +242,8 @@ struct MeterView: View {
   private var safeAreaTop: CGFloat { windowSafeAreaInsets.top }
   private var safeAreaBottom: CGFloat { windowSafeAreaInsets.bottom }
 
-  private func rainConditionButton(metrics: ControlBarMetrics) -> some View {
-    ConditionTileButton(systemImage: "cloud.rain.fill", label: "Rain", isOn: bindingFor(\.isRaining), metrics: metrics)
-  }
-
   private func nightConditionButton(metrics: ControlBarMetrics) -> some View {
     ConditionTileButton(systemImage: "moon.stars.fill", label: "Night", isOn: bindingFor(\.isNight), isInteractive: false, metrics: metrics)
-  }
-
-  private func trafficConditionButton(metrics: ControlBarMetrics) -> some View {
-    ConditionTileButton(systemImage: "car.2.fill", label: "Traffic", isOn: bindingFor(\.isHeavyTraffic), metrics: metrics)
   }
 
   private func tripToggleButton(metrics: ControlBarMetrics) -> some View {
@@ -304,7 +296,7 @@ struct MeterView: View {
       let horizontalPadding: CGFloat = 10
       let verticalPadding: CGFloat = 6
       let spacing: CGFloat = 6
-      let tileCount = CGFloat(6)
+      let tileCount = CGFloat(4)
       let availableWidth = max(geo.size.width - (horizontalPadding * 2), 0)
       let availableHeight = max(geo.size.height - (verticalPadding * 2), 0)
       let tileWidth = max((availableWidth - spacing * (tileCount - 1)) / tileCount, 0)
@@ -316,9 +308,7 @@ struct MeterView: View {
       HStack(spacing: spacing) {
         tripToggleButton(metrics: metrics)
         waitToggleButton(metrics: metrics)
-        rainConditionButton(metrics: metrics)
         nightConditionButton(metrics: metrics)
-        trafficConditionButton(metrics: metrics)
         meterSettingsButton(metrics: metrics)
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)

--- a/NammaMeter/Models.swift
+++ b/NammaMeter/Models.swift
@@ -33,58 +33,118 @@ struct TripPoint: Codable, Hashable, Identifiable, Sendable {
   }
 }
 
-struct TripConditions: Codable, Equatable, Sendable {
-  var isRaining: Bool
+struct TripConditions: Equatable, Sendable {
   var isNight: Bool
-  var isHeavyTraffic: Bool
 
-  static let clear = TripConditions(isRaining: false, isNight: false, isHeavyTraffic: false)
+  static let clear = TripConditions(isNight: false)
 
   func multiplier(using settings: MeterSettings) -> Double {
-    let rain = isRaining ? settings.rainMultiplier : 1
-    let night = isNight ? settings.nightMultiplier : 1
-    let traffic = isHeavyTraffic ? settings.trafficMultiplier : 1
-    return rain * night * traffic
+    isNight ? settings.nightMultiplier : 1
   }
 }
 
-struct MeterSettings: Codable, Equatable, Sendable {
+extension TripConditions: Codable {
+  enum CodingKeys: String, CodingKey {
+    case isNight
+    case isRaining // legacy, ignored on decode
+    case isHeavyTraffic // legacy, ignored on decode
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    isNight = try container.decode(Bool.self, forKey: .isNight)
+    // Discard legacy rain/traffic fields if present
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(isNight, forKey: .isNight)
+  }
+}
+
+struct MeterSettings: Equatable, Sendable {
   var baseFare: Double
   var perKmRate: Double
   var perMinuteRate: Double
   var minFare: Double
-  var rainMultiplier: Double
   var nightMultiplier: Double
-  var trafficMultiplier: Double
 
   static let bengaluruDefault = MeterSettings(
     baseFare: 30,
     perKmRate: 15,
     perMinuteRate: 1.5,
     minFare: 30,
-    rainMultiplier: 1.2,
-    nightMultiplier: 1.25,
-    trafficMultiplier: 1.15
+    nightMultiplier: 1.25
   )
 }
 
-struct RateSnapshot: Codable, Equatable, Sendable {
+extension MeterSettings: Codable {
+  enum CodingKeys: String, CodingKey {
+    case baseFare, perKmRate, perMinuteRate, minFare, nightMultiplier
+    case rainMultiplier // legacy, ignored on decode
+    case trafficMultiplier // legacy, ignored on decode
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    baseFare = try container.decode(Double.self, forKey: .baseFare)
+    perKmRate = try container.decode(Double.self, forKey: .perKmRate)
+    perMinuteRate = try container.decode(Double.self, forKey: .perMinuteRate)
+    minFare = try container.decode(Double.self, forKey: .minFare)
+    nightMultiplier = try container.decode(Double.self, forKey: .nightMultiplier)
+    // Discard legacy rain/traffic multipliers if present
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(baseFare, forKey: .baseFare)
+    try container.encode(perKmRate, forKey: .perKmRate)
+    try container.encode(perMinuteRate, forKey: .perMinuteRate)
+    try container.encode(minFare, forKey: .minFare)
+    try container.encode(nightMultiplier, forKey: .nightMultiplier)
+  }
+}
+
+struct RateSnapshot: Equatable, Sendable {
   let baseFare: Double
   let perKmRate: Double
   let perMinuteRate: Double
   let minFare: Double
-  let rainMultiplier: Double
   let nightMultiplier: Double
-  let trafficMultiplier: Double
 
   init(settings: MeterSettings) {
     baseFare = settings.baseFare
     perKmRate = settings.perKmRate
     perMinuteRate = settings.perMinuteRate
     minFare = settings.minFare
-    rainMultiplier = settings.rainMultiplier
     nightMultiplier = settings.nightMultiplier
-    trafficMultiplier = settings.trafficMultiplier
+  }
+}
+
+extension RateSnapshot: Codable {
+  enum CodingKeys: String, CodingKey {
+    case baseFare, perKmRate, perMinuteRate, minFare, nightMultiplier
+    case rainMultiplier // legacy, ignored on decode
+    case trafficMultiplier // legacy, ignored on decode
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    baseFare = try container.decode(Double.self, forKey: .baseFare)
+    perKmRate = try container.decode(Double.self, forKey: .perKmRate)
+    perMinuteRate = try container.decode(Double.self, forKey: .perMinuteRate)
+    minFare = try container.decode(Double.self, forKey: .minFare)
+    nightMultiplier = try container.decode(Double.self, forKey: .nightMultiplier)
+    // Discard legacy rain/traffic multipliers if present
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(baseFare, forKey: .baseFare)
+    try container.encode(perKmRate, forKey: .perKmRate)
+    try container.encode(perMinuteRate, forKey: .perMinuteRate)
+    try container.encode(minFare, forKey: .minFare)
+    try container.encode(nightMultiplier, forKey: .nightMultiplier)
   }
 }
 

--- a/NammaMeter/SettingsView.swift
+++ b/NammaMeter/SettingsView.swift
@@ -46,19 +46,9 @@ struct SettingsView: View {
 
           Section(header: SectionHeader(title: "Modifiers", subtitle: "ಗುಣಕಗಳು")) {
             LabeledNumberField(
-              title: "Rain Multiplier",
-              subtitle: "ಮಳೆ ಗುಣಕ",
-              value: $settingsStore.settings.rainMultiplier
-            )
-            LabeledNumberField(
               title: "Night Multiplier",
               subtitle: "ರಾತ್ರಿ ಗುಣಕ",
               value: $settingsStore.settings.nightMultiplier
-            )
-            LabeledNumberField(
-              title: "Traffic Multiplier",
-              subtitle: "ಟ್ರಾಫಿಕ್ ಗುಣಕ",
-              value: $settingsStore.settings.trafficMultiplier
             )
           }
 

--- a/NammaMeter/TripDetailView.swift
+++ b/NammaMeter/TripDetailView.swift
@@ -99,11 +99,7 @@ struct TripDetailView: View {
         SummaryChip(title: "Wait", value: formattedElapsed(trip.waitingDuration))
       }
 
-      HStack(spacing: 8) {
-        ConditionBadge(title: "Rain", subtitle: "ಮಳೆ", isOn: trip.conditions.isRaining)
-        ConditionBadge(title: "Night", subtitle: "ರಾತ್ರಿ", isOn: trip.conditions.isNight)
-        ConditionBadge(title: "Traffic", subtitle: "ಟ್ರಾಫಿಕ್", isOn: trip.conditions.isHeavyTraffic)
-      }
+      ConditionBadge(title: "Night", subtitle: "ರಾತ್ರಿ", isOn: trip.conditions.isNight)
     }
     .cardStyle()
   }


### PR DESCRIPTION
## Summary
- Remove rain and traffic condition toggles from meter control bar
- Remove rain and traffic multiplier settings
- Remove rain and traffic badges from trip detail view
- Add backward-compatible Codable handling to discard legacy persisted fields

Closes #19

## Context
Fare calculation does not actually apply rain or traffic modifiers. These controls were causing user confusion since toggling them had no effect on the calculated fare.

## Test plan
- [x] Verify build succeeds
- [x] Verify meter control bar shows only 4 buttons (trip toggle, wait, night, settings)
- [x] Verify settings shows only night multiplier under Modifiers
- [x] Verify trip detail view shows only night condition badge
- [x] Verify app can load persisted trips/settings with legacy rain/traffic fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)