### PR TITLE
Add free-wait + interval-based waiting charges

### DIFF
--- a/NammaMeter/MeterStore.swift
+++ b/NammaMeter/MeterStore.swift
@@ -172,10 +172,28 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
     let distanceKm = distanceMeters / 1000
     let includedKm = 2.0
     let chargeableDistanceKm = max(0, distanceKm - includedKm)
-    let waitingMinutes = waitingDuration / 60
-    let rawFare = settings.baseFare + (chargeableDistanceKm * settings.perKmRate) + (waitingMinutes * settings.perMinuteRate)
+    let waitingCharge = calculateWaitingCharge(
+      waitingDuration: waitingDuration,
+      freeWaitMinutes: settings.freeWaitMinutes,
+      waitIntervalMinutes: settings.waitIntervalMinutes,
+      waitIntervalCharge: settings.waitIntervalCharge
+    )
+    let rawFare = settings.baseFare + (chargeableDistanceKm * settings.perKmRate) + waitingCharge
     let adjusted = rawFare * multiplier
     fare = max(settings.minFare, adjusted)
+  }
+
+  private func calculateWaitingCharge(
+    waitingDuration: TimeInterval,
+    freeWaitMinutes: Double,
+    waitIntervalMinutes: Double,
+    waitIntervalCharge: Double
+  ) -> Double {
+    let waitingMinutes = waitingDuration / 60
+    let chargeableMinutes = max(0, waitingMinutes - freeWaitMinutes)
+    guard waitIntervalMinutes > 0 else { return 0 }
+    let intervals = ceil(chargeableMinutes / waitIntervalMinutes)
+    return intervals * waitIntervalCharge
   }
 
   func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {

--- a/NammaMeter/Models.swift
+++ b/NammaMeter/Models.swift
@@ -65,22 +65,29 @@ extension TripConditions: Codable {
 struct MeterSettings: Equatable, Sendable {
   var baseFare: Double
   var perKmRate: Double
-  var perMinuteRate: Double
+  var perMinuteRate: Double // Legacy, kept for backward compatibility
   var minFare: Double
   var nightMultiplier: Double
+  var freeWaitMinutes: Double
+  var waitIntervalMinutes: Double
+  var waitIntervalCharge: Double
 
   static let bengaluruDefault = MeterSettings(
     baseFare: 30,
     perKmRate: 15,
     perMinuteRate: 1.5,
     minFare: 30,
-    nightMultiplier: 1.25
+    nightMultiplier: 1.25,
+    freeWaitMinutes: 5,
+    waitIntervalMinutes: 15,
+    waitIntervalCharge: 10
   )
 }
 
 extension MeterSettings: Codable {
   enum CodingKeys: String, CodingKey {
     case baseFare, perKmRate, perMinuteRate, minFare, nightMultiplier
+    case freeWaitMinutes, waitIntervalMinutes, waitIntervalCharge
     case rainMultiplier // legacy, ignored on decode
     case trafficMultiplier // legacy, ignored on decode
   }
@@ -92,7 +99,13 @@ extension MeterSettings: Codable {
     perMinuteRate = try container.decode(Double.self, forKey: .perMinuteRate)
     minFare = try container.decode(Double.self, forKey: .minFare)
     nightMultiplier = try container.decode(Double.self, forKey: .nightMultiplier)
-    // Discard legacy rain/traffic multipliers if present
+    // New fields with backward-compatible defaults for old persisted data
+    freeWaitMinutes = try container.decodeIfPresent(Double.self, forKey: .freeWaitMinutes)
+      ?? MeterSettings.bengaluruDefault.freeWaitMinutes
+    waitIntervalMinutes = try container.decodeIfPresent(Double.self, forKey: .waitIntervalMinutes)
+      ?? MeterSettings.bengaluruDefault.waitIntervalMinutes
+    waitIntervalCharge = try container.decodeIfPresent(Double.self, forKey: .waitIntervalCharge)
+      ?? MeterSettings.bengaluruDefault.waitIntervalCharge
   }
 
   func encode(to encoder: Encoder) throws {
@@ -102,15 +115,21 @@ extension MeterSettings: Codable {
     try container.encode(perMinuteRate, forKey: .perMinuteRate)
     try container.encode(minFare, forKey: .minFare)
     try container.encode(nightMultiplier, forKey: .nightMultiplier)
+    try container.encode(freeWaitMinutes, forKey: .freeWaitMinutes)
+    try container.encode(waitIntervalMinutes, forKey: .waitIntervalMinutes)
+    try container.encode(waitIntervalCharge, forKey: .waitIntervalCharge)
   }
 }
 
 struct RateSnapshot: Equatable, Sendable {
   let baseFare: Double
   let perKmRate: Double
-  let perMinuteRate: Double
+  let perMinuteRate: Double // Legacy, kept for backward compatibility
   let minFare: Double
   let nightMultiplier: Double
+  let freeWaitMinutes: Double
+  let waitIntervalMinutes: Double
+  let waitIntervalCharge: Double
 
   init(settings: MeterSettings) {
     baseFare = settings.baseFare
@@ -118,12 +137,16 @@ struct RateSnapshot: Equatable, Sendable {
     perMinuteRate = settings.perMinuteRate
     minFare = settings.minFare
     nightMultiplier = settings.nightMultiplier
+    freeWaitMinutes = settings.freeWaitMinutes
+    waitIntervalMinutes = settings.waitIntervalMinutes
+    waitIntervalCharge = settings.waitIntervalCharge
   }
 }
 
 extension RateSnapshot: Codable {
   enum CodingKeys: String, CodingKey {
     case baseFare, perKmRate, perMinuteRate, minFare, nightMultiplier
+    case freeWaitMinutes, waitIntervalMinutes, waitIntervalCharge
     case rainMultiplier // legacy, ignored on decode
     case trafficMultiplier // legacy, ignored on decode
   }
@@ -135,7 +158,13 @@ extension RateSnapshot: Codable {
     perMinuteRate = try container.decode(Double.self, forKey: .perMinuteRate)
     minFare = try container.decode(Double.self, forKey: .minFare)
     nightMultiplier = try container.decode(Double.self, forKey: .nightMultiplier)
-    // Discard legacy rain/traffic multipliers if present
+    // New fields with backward-compatible defaults for old persisted trips
+    freeWaitMinutes = try container.decodeIfPresent(Double.self, forKey: .freeWaitMinutes)
+      ?? MeterSettings.bengaluruDefault.freeWaitMinutes
+    waitIntervalMinutes = try container.decodeIfPresent(Double.self, forKey: .waitIntervalMinutes)
+      ?? MeterSettings.bengaluruDefault.waitIntervalMinutes
+    waitIntervalCharge = try container.decodeIfPresent(Double.self, forKey: .waitIntervalCharge)
+      ?? MeterSettings.bengaluruDefault.waitIntervalCharge
   }
 
   func encode(to encoder: Encoder) throws {
@@ -145,6 +174,9 @@ extension RateSnapshot: Codable {
     try container.encode(perMinuteRate, forKey: .perMinuteRate)
     try container.encode(minFare, forKey: .minFare)
     try container.encode(nightMultiplier, forKey: .nightMultiplier)
+    try container.encode(freeWaitMinutes, forKey: .freeWaitMinutes)
+    try container.encode(waitIntervalMinutes, forKey: .waitIntervalMinutes)
+    try container.encode(waitIntervalCharge, forKey: .waitIntervalCharge)
   }
 }
 

--- a/NammaMeter/SettingsView.swift
+++ b/NammaMeter/SettingsView.swift
@@ -33,14 +33,27 @@ struct SettingsView: View {
               value: $settingsStore.settings.perKmRate
             )
             LabeledNumberField(
-              title: "Wait Per Minute",
-              subtitle: "ನಿಲ್ಲಿಕೆ ಪ್ರತಿ ನಿಮಿಷ",
-              value: $settingsStore.settings.perMinuteRate
-            )
-            LabeledNumberField(
               title: "Minimum Fare",
               subtitle: "ಕನಿಷ್ಠ ಬಾಡಿಗೆ",
               value: $settingsStore.settings.minFare
+            )
+          }
+
+          Section(header: SectionHeader(title: "Waiting Charges", subtitle: "ನಿಲ್ಲಿಕೆ ಶುಲ್ಕಗಳು")) {
+            LabeledNumberField(
+              title: "Free Wait (min)",
+              subtitle: "ಉಚಿತ ನಿಲ್ಲಿಕೆ (ನಿಮಿಷ)",
+              value: $settingsStore.settings.freeWaitMinutes
+            )
+            LabeledNumberField(
+              title: "Interval (min)",
+              subtitle: "ಮಧ್ಯಂತರ (ನಿಮಿಷ)",
+              value: $settingsStore.settings.waitIntervalMinutes
+            )
+            LabeledNumberField(
+              title: "Per Interval",
+              subtitle: "ಪ್ರತಿ ಮಧ್ಯಂತರ",
+              value: $settingsStore.settings.waitIntervalCharge
             )
           }
 

--- a/NammaMeter/TripDetailView.swift
+++ b/NammaMeter/TripDetailView.swift
@@ -207,8 +207,12 @@ struct TripDetailView: View {
         RateLine(title: "Per Km", subtitle: "ಪ್ರತಿ ಕಿಮೀ", value: trip.rateSnapshot.perKmRate)
       }
       HStack {
-        RateLine(title: "Wait Per Minute", subtitle: "ನಿಲ್ಲಿಕೆ ಪ್ರತಿ ನಿಮಿಷ", value: trip.rateSnapshot.perMinuteRate)
         RateLine(title: "Min Fare", subtitle: "ಕನಿಷ್ಠ ಬಾಡಿಗೆ", value: trip.rateSnapshot.minFare)
+        RateLine(title: "Free Wait", subtitle: "ಉಚಿತ ನಿಲ್ಲಿಕೆ", value: trip.rateSnapshot.freeWaitMinutes)
+      }
+      HStack {
+        RateLine(title: "Wait Interval", subtitle: "ನಿಲ್ಲಿಕೆ ಮಧ್ಯಂತರ", value: trip.rateSnapshot.waitIntervalMinutes)
+        RateLine(title: "Per Interval", subtitle: "ಪ್ರತಿ ಮಧ್ಯಂತರ", value: trip.rateSnapshot.waitIntervalCharge)
       }
     }
     .cardStyle()


### PR DESCRIPTION
## Summary
- Replaces per-minute waiting charges with an interval-based billing model
- First N minutes are free, then charges accrue in fixed intervals (ceil to next interval)
- Adds 3 new settings: free wait duration, interval duration, charge per interval
- Legacy `perMinuteRate` is not migrated; missing new fields default to Bengaluru values, which may change fares for existing users/trips

## Changes
| File | Change |
|------|--------|
| `Models.swift` | Added `freeWaitMinutes`, `waitIntervalMinutes`, `waitIntervalCharge` to `MeterSettings` and `RateSnapshot` with backward-compatible decoding |
| `MeterStore.swift` | New `calculateWaitingCharge()` function using interval-based logic |
| `SettingsView.swift` | New "Waiting Charges" section with 3 configurable fields |
| `TripDetailView.swift` | Updated rate snapshot display with new fields |

## Default values (Bengaluru)
- Free wait: 5 minutes
- Interval: 15 minutes  
- Per interval: ₹10

## Test plan
- [x] Build and run app
- [x] Verify Settings shows new "Waiting Charges" section with 3 fields
- [x] Start trip, toggle waiting < 5 min → verify no waiting charge
- [x] Toggle waiting > 5 min → verify charges accrue in 15-min intervals
- [x] Load existing trips → verify they display with default waiting settings
- [x] Reset to defaults → verify all new fields reset correctly

Closes #20
