### PR TITLE
Add tests for interval-based waiting charges

### DIFF
--- a/NammaMeter/MeterStore.swift
+++ b/NammaMeter/MeterStore.swift
@@ -183,7 +183,7 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
     fare = max(settings.minFare, adjusted)
   }
 
-  private func calculateWaitingCharge(
+  func calculateWaitingCharge(
     waitingDuration: TimeInterval,
     freeWaitMinutes: Double,
     waitIntervalMinutes: Double,

--- a/NammaMeterTests/BackwardCompatibilityTests.swift
+++ b/NammaMeterTests/BackwardCompatibilityTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import XCTest
+@testable import NammaMeter
+
+final class BackwardCompatibilityTests: XCTestCase {
+  func testDecodeMeterSettingsDefaultsForWaitingFields() throws {
+    let json = """
+    {
+      "baseFare": 30,
+      "perKmRate": 15,
+      "perMinuteRate": 1.5,
+      "minFare": 30,
+      "nightMultiplier": 1.25
+    }
+    """
+    let data = Data(json.utf8)
+    let decoded = try JSONDecoder().decode(MeterSettings.self, from: data)
+    let defaults = MeterSettings.bengaluruDefault
+
+    XCTAssertEqual(decoded.freeWaitMinutes, defaults.freeWaitMinutes)
+    XCTAssertEqual(decoded.waitIntervalMinutes, defaults.waitIntervalMinutes)
+    XCTAssertEqual(decoded.waitIntervalCharge, defaults.waitIntervalCharge)
+  }
+
+  func testDecodeRateSnapshotDefaultsForWaitingFields() throws {
+    let json = """
+    {
+      "baseFare": 30,
+      "perKmRate": 15,
+      "perMinuteRate": 1.5,
+      "minFare": 30,
+      "nightMultiplier": 1.25
+    }
+    """
+    let data = Data(json.utf8)
+    let decoded = try JSONDecoder().decode(RateSnapshot.self, from: data)
+    let defaults = MeterSettings.bengaluruDefault
+
+    XCTAssertEqual(decoded.freeWaitMinutes, defaults.freeWaitMinutes)
+    XCTAssertEqual(decoded.waitIntervalMinutes, defaults.waitIntervalMinutes)
+    XCTAssertEqual(decoded.waitIntervalCharge, defaults.waitIntervalCharge)
+  }
+
+  func testDecodeTripRateSnapshotDefaultsForWaitingFields() throws {
+    let json = """
+    {
+      "id": "E13E6F3C-6C7E-4F51-9E14-6B7A2F5DABCD",
+      "startDate": 0,
+      "endDate": 60,
+      "distanceMeters": 1000,
+      "duration": 60,
+      "fare": 50,
+      "points": [],
+      "conditions": { "isNight": false },
+      "rateSnapshot": {
+        "baseFare": 30,
+        "perKmRate": 15,
+        "perMinuteRate": 1.5,
+        "minFare": 30,
+        "nightMultiplier": 1.25
+      },
+      "multiplier": 1,
+      "waitingDuration": 0
+    }
+    """
+    let data = Data(json.utf8)
+    let decoded = try JSONDecoder().decode(Trip.self, from: data)
+    let defaults = MeterSettings.bengaluruDefault
+
+    XCTAssertEqual(decoded.rateSnapshot.freeWaitMinutes, defaults.freeWaitMinutes)
+    XCTAssertEqual(decoded.rateSnapshot.waitIntervalMinutes, defaults.waitIntervalMinutes)
+    XCTAssertEqual(decoded.rateSnapshot.waitIntervalCharge, defaults.waitIntervalCharge)
+  }
+}

--- a/NammaMeterTests/WaitingChargeTests.swift
+++ b/NammaMeterTests/WaitingChargeTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import NammaMeter
+
+@MainActor
+final class WaitingChargeTests: XCTestCase {
+  private let store = MeterStore()
+
+  private func charge(
+    waitingMinutes: Double,
+    freeWaitMinutes: Double = 5,
+    intervalMinutes: Double = 15,
+    intervalCharge: Double = 10
+  ) -> Double {
+    store.calculateWaitingCharge(
+      waitingDuration: waitingMinutes * 60,
+      freeWaitMinutes: freeWaitMinutes,
+      waitIntervalMinutes: intervalMinutes,
+      waitIntervalCharge: intervalCharge
+    )
+  }
+
+  func testFreeWaitPeriodIsNotCharged() {
+    let cases: [(Double, Double)] = [
+      (0, 0),
+      (3, 0),
+      (5, 0)
+    ]
+
+    for (waitingMinutes, expected) in cases {
+      XCTAssertEqual(charge(waitingMinutes: waitingMinutes), expected, "waitingMinutes=\(waitingMinutes)")
+    }
+  }
+
+  func testIntervalBillingAfterFreeWait() {
+    let cases: [(Double, Double)] = [
+      (6, 10),
+      (20, 10),
+      (21, 20),
+      (35, 20),
+      (36, 30)
+    ]
+
+    for (waitingMinutes, expected) in cases {
+      XCTAssertEqual(charge(waitingMinutes: waitingMinutes), expected, "waitingMinutes=\(waitingMinutes)")
+    }
+  }
+
+  func testEdgeCases() {
+    XCTAssertEqual(charge(waitingMinutes: 10, intervalMinutes: 0), 0)
+    XCTAssertEqual(charge(waitingMinutes: 10, intervalMinutes: -5), 0)
+    XCTAssertEqual(charge(waitingMinutes: 10, freeWaitMinutes: 0), 10)
+    XCTAssertEqual(charge(waitingMinutes: 20, intervalCharge: 0), 0)
+  }
+}


### PR DESCRIPTION
## Summary
- cover free-wait, interval billing, and edge cases for waiting charge calculation
- verify backward-compatible decoding of waiting fields in MeterSettings, RateSnapshot, and Trip
- expose waiting charge helper for test coverage

## Testing
- xcodebuild -project NammaMeter.xcodeproj -scheme NammaMeter -destination 'platform=iOS Simulator,name=iPhone 17' test

Closes #29 