### PR TITLE
Add MeterCapabilities system and hide digit style for non-mechanical meters

### DIFF
--- a/NammaMeter/MeterTypes.swift
+++ b/NammaMeter/MeterTypes.swift
@@ -1,6 +1,42 @@
 import SwiftUI
 import UIKit
 
+// MARK: - Meter Category
+
+enum MeterCategory {
+  case mechanical
+  case electronic
+}
+
+// MARK: - Display Fields
+
+enum MeterDisplayField {
+  case fare
+  case waitTime
+  case distance
+}
+
+// MARK: - Status Indicators
+
+enum MeterStatusIndicator {
+  case forHire
+  case hired
+  case stop
+  case nightMode
+}
+
+// MARK: - Meter Capabilities
+
+struct MeterCapabilities {
+  let category: MeterCategory
+  let displayFields: Set<MeterDisplayField>
+  let statusIndicators: Set<MeterStatusIndicator>
+
+  var isMechanical: Bool { category == .mechanical }
+  var showsWaitTime: Bool { displayFields.contains(.waitTime) }
+  var showsDistance: Bool { displayFields.contains(.distance) }
+}
+
 // MARK: - Meter Face Style
 
 enum MeterFaceStyle: String, CaseIterable, Identifiable {
@@ -24,6 +60,41 @@ enum MeterFaceStyle: String, CaseIterable, Identifiable {
       return "display"
     case .brightDigital:
       return "rectangle.3.offgrid"
+    }
+  }
+
+  var capabilities: MeterCapabilities {
+    switch self {
+    case .superMeter:
+      return MeterCapabilities(
+        category: .mechanical,
+        displayFields: [.fare],
+        statusIndicators: [.forHire]
+      )
+    case .superElectronic:
+      return MeterCapabilities(
+        category: .electronic,
+        displayFields: [.fare, .waitTime, .distance],
+        statusIndicators: [.forHire, .hired, .stop, .nightMode]
+      )
+    case .goldenEagle:
+      return MeterCapabilities(
+        category: .electronic,
+        displayFields: [.fare, .waitTime, .distance],
+        statusIndicators: [.forHire]
+      )
+    case .digital:
+      return MeterCapabilities(
+        category: .electronic,
+        displayFields: [.fare],
+        statusIndicators: [.forHire]
+      )
+    case .brightDigital:
+      return MeterCapabilities(
+        category: .electronic,
+        displayFields: [.fare, .waitTime, .distance],
+        statusIndicators: [.forHire]
+      )
     }
   }
 }

--- a/NammaMeter/MeterView.swift
+++ b/NammaMeter/MeterView.swift
@@ -481,17 +481,19 @@ struct MeterView: View {
         }
       }
     }
-    Section("Digit Style") {
-      ForEach(DigitWheelStyle.allCases) { style in
-        Button {
-          digitWheelStyle = style
-        } label: {
-          HStack {
-            Text(style.label)
-            Spacer()
-            if digitWheelStyle == style {
-              Image(systemName: "checkmark")
-                .foregroundStyle(Theme.ink)
+    if meterFaceStyle.capabilities.isMechanical {
+      Section("Digit Style") {
+        ForEach(DigitWheelStyle.allCases) { style in
+          Button {
+            digitWheelStyle = style
+          } label: {
+            HStack {
+              Text(style.label)
+              Spacer()
+              if digitWheelStyle == style {
+                Image(systemName: "checkmark")
+                  .foregroundStyle(Theme.ink)
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- Add `MeterCapabilities` system to expose meter properties (category, display fields, status indicators)
- Hide Digit Style selector (Drum/Disk) for electronic meters since it only applies to Super Mechanical

## Changes
- **New types in MeterTypes.swift:**
  - `MeterCategory` enum (`.mechanical`, `.electronic`)
  - `MeterDisplayField` enum (`.fare`, `.waitTime`, `.distance`)
  - `MeterStatusIndicator` enum (`.forHire`, `.hired`, `.stop`, `.nightMode`)
  - `MeterCapabilities` struct with convenience properties (`isMechanical`, `showsWaitTime`, `showsDistance`)
- **MeterFaceStyle:** Added `capabilities` computed property returning appropriate `MeterCapabilities` for each meter type
- **Settings UI:** Digit Style section now conditionally shown only when `meterFaceStyle.capabilities.isMechanical`

## Test plan
- [x] Build succeeds with no warnings
- [x] Select Super Mechanical meter → Digit Style section appears in settings
- [x] Select Super Electronic meter → Digit Style section hidden
- [x] Select Golden Eagle meter → Digit Style section hidden
- [x] Select Neo Digital meter → Digit Style section hidden
- [x] Select Bright Digital meter → Digit Style section hidden

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)