### PR TITLE
Add city fare management UI with dropdown selection

### DIFF
--- a/NammaMeter/AddCityView.swift
+++ b/NammaMeter/AddCityView.swift
@@ -1,23 +1,18 @@
 import SwiftUI
 
 struct AddCityView: View {
-  @Environment(SettingsStore.self) private var settingsStore
   @Environment(\.dismiss) private var dismiss
 
   @State private var name: String = ""
-  @State private var baseFare: Double = 36
-  @State private var perKmRate: Double = 18
-  @State private var minFare: Double = 36
-  @State private var includedKm: Double = 2.0
-  @State private var nightMultiplier: Double = 1.5
-  @State private var nightStartHour: Int = 22
-  @State private var nightEndHour: Int = 5
-  @State private var freeWaitMinutes: Double = 5
-  @State private var waitIntervalMinutes: Double = 15
-  @State private var waitIntervalCharge: Double = 10
+  @State private var navigateToAddFare = false
+  @State private var generatedCityId: String = ""
 
-  private var canSave: Bool {
-    !name.trimmingCharacters(in: .whitespaces).isEmpty
+  private var trimmedName: String {
+    name.trimmingCharacters(in: .whitespaces)
+  }
+
+  private var canProceed: Bool {
+    !trimmedName.isEmpty
   }
 
   var body: some View {
@@ -28,102 +23,34 @@ struct AddCityView: View {
           TextField("Name", text: $name)
             .font(.nammaDisplay(14))
         }
-
-        Section(header: SectionHeader(title: "Rates", subtitle: "ದರಗಳು")) {
-          LabeledNumberField(
-            title: "Base Fare",
-            subtitle: "ಮೂಲ ಬಾಡಿಗೆ",
-            value: $baseFare
-          )
-          LabeledNumberField(
-            title: "Per Km",
-            subtitle: "ಪ್ರತಿ ಕಿಲೋ ಮೀಟರ್",
-            value: $perKmRate
-          )
-          LabeledNumberField(
-            title: "Minimum Fare",
-            subtitle: "ಕನಿಷ್ಠ ಬಾಡಿಗೆ",
-            value: $minFare
-          )
-          LabeledNumberField(
-            title: "Included Km",
-            subtitle: "ಸೇರಿಸಿದ ಕಿಮೀ",
-            value: $includedKm
-          )
-        }
-
-        Section(header: SectionHeader(title: "Waiting Charges", subtitle: "ನಿಲ್ಲಿಕೆ ಶುಲ್ಕಗಳು")) {
-          LabeledNumberField(
-            title: "Free Wait (min)",
-            subtitle: "ಉಚಿತ ನಿಲ್ಲಿಕೆ (ನಿಮಿಷ)",
-            value: $freeWaitMinutes
-          )
-          LabeledNumberField(
-            title: "Interval (min)",
-            subtitle: "ಮಧ್ಯಂತರ (ನಿಮಿಷ)",
-            value: $waitIntervalMinutes
-          )
-          LabeledNumberField(
-            title: "Per Interval",
-            subtitle: "ಪ್ರತಿ ಮಧ್ಯಂತರ",
-            value: $waitIntervalCharge
-          )
-        }
-
-        Section(header: SectionHeader(title: "Night Fare", subtitle: "ರಾತ್ರಿ ಬಾಡಿಗೆ")) {
-          LabeledNumberField(
-            title: "Night Multiplier",
-            subtitle: "ರಾತ್ರಿ ಗುಣಕ",
-            value: $nightMultiplier
-          )
-          Stepper("Start Hour: \(nightStartHour):00", value: $nightStartHour, in: 0...23)
-          Stepper("End Hour: \(nightEndHour):00", value: $nightEndHour, in: 0...23)
-        }
       }
       .scrollContentBackground(.hidden)
     }
     .navigationTitle("Add City")
     .navigationBarTitleDisplayMode(.inline)
+    .navigationDestination(isPresented: $navigateToAddFare) {
+      AddFareView(cityId: generatedCityId, cityName: trimmedName, isNewCity: true)
+    }
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {
         Button("Cancel") { dismiss() }
       }
       ToolbarItem(placement: .confirmationAction) {
-        Button("Save") { save() }
-          .disabled(!canSave)
+        Button("Next") {
+          generatedCityId = "custom-\(UUID().uuidString)"
+          navigateToAddFare = true
+        }
+        .disabled(!canProceed)
+      }
+      ToolbarItem(placement: .principal) {
+        VStack(spacing: 2) {
+          Text("Add City")
+            .font(.nammaDisplay(16))
+          Text("ನಗರವನ್ನು ಸೇರಿಸಿ")
+            .font(.nammaBody(11))
+        }
       }
     }
-  }
-
-  private func save() {
-    let trimmedName = name.trimmingCharacters(in: .whitespaces)
-    guard !trimmedName.isEmpty else { return }
-
-    let cityId = "custom-\(UUID().uuidString)"
-    let profile = CityFareProfile(
-      id: UUID().uuidString,
-      cityId: cityId,
-      name: trimmedName,
-      cityKey: CityKey(city: trimmedName, region: nil, countryCode: "IN"),
-      rates: FareRates(
-        baseFare: baseFare,
-        perKmRate: perKmRate,
-        perMinuteRate: 0,
-        includedKm: includedKm,
-        minFare: minFare
-      ),
-      multipliers: FareMultipliers(night: nightMultiplier),
-      nightWindow: NightFareWindow(startHour: nightStartHour, endHour: nightEndHour),
-      waitCharges: WaitingChargePolicy(
-        freeWaitMinutes: freeWaitMinutes,
-        waitIntervalMinutes: waitIntervalMinutes,
-        waitIntervalCharge: waitIntervalCharge
-      ),
-      effectiveFrom: Date()
-    )
-
-    settingsStore.addCity(profile)
-    dismiss()
   }
 }
 

--- a/NammaMeter/AddFareView.swift
+++ b/NammaMeter/AddFareView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+struct AddFareView: View {
+  @Environment(SettingsStore.self) private var settingsStore
+  @Environment(\.dismiss) private var dismiss
+
+  let cityId: String
+  let cityName: String
+  var isNewCity: Bool = false
+
+  @State private var effectiveFrom: Date = Date()
+  @State private var baseFare: Double = 36
+  @State private var perKmRate: Double = 18
+  @State private var minFare: Double = 36
+  @State private var includedKm: Double = 2.0
+  @State private var nightMultiplier: Double = 1.5
+  @State private var nightStartHour: Int = 22
+  @State private var nightEndHour: Int = 5
+  @State private var freeWaitMinutes: Double = 5
+  @State private var waitIntervalMinutes: Double = 15
+  @State private var waitIntervalCharge: Double = 10
+
+  var body: some View {
+    ZStack {
+      NammaBackground()
+      Form {
+        Section(header: SectionHeader(title: "Effective Date", subtitle: "ಜಾರಿ ದಿನಾಂಕ")) {
+          DatePicker(
+            "Effective From",
+            selection: $effectiveFrom,
+            displayedComponents: .date
+          )
+        }
+
+        Section(header: SectionHeader(title: "Rates", subtitle: "ದರಗಳು")) {
+          LabeledNumberField(
+            title: "Base Fare",
+            subtitle: "ಮೂಲ ಬಾಡಿಗೆ",
+            value: $baseFare
+          )
+          LabeledNumberField(
+            title: "Per Km",
+            subtitle: "ಪ್ರತಿ ಕಿಲೋ ಮೀಟರ್",
+            value: $perKmRate
+          )
+          LabeledNumberField(
+            title: "Minimum Fare",
+            subtitle: "ಕನಿಷ್ಠ ಬಾಡಿಗೆ",
+            value: $minFare
+          )
+          LabeledNumberField(
+            title: "Included Km",
+            subtitle: "ಸೇರಿಸಿದ ಕಿಮೀ",
+            value: $includedKm
+          )
+        }
+
+        Section(header: SectionHeader(title: "Waiting Charges", subtitle: "ನಿಲ್ಲಿಕೆ ಶುಲ್ಕಗಳು")) {
+          LabeledNumberField(
+            title: "Free Wait (min)",
+            subtitle: "ಉಚಿತ ನಿಲ್ಲಿಕೆ (ನಿಮಿಷ)",
+            value: $freeWaitMinutes
+          )
+          LabeledNumberField(
+            title: "Interval (min)",
+            subtitle: "ಮಧ್ಯಂತರ (ನಿಮಿಷ)",
+            value: $waitIntervalMinutes
+          )
+          LabeledNumberField(
+            title: "Per Interval",
+            subtitle: "ಪ್ರತಿ ಮಧ್ಯಂತರ",
+            value: $waitIntervalCharge
+          )
+        }
+
+        Section(header: SectionHeader(title: "Night Fare", subtitle: "ರಾತ್ರಿ ಬಾಡಿಗೆ")) {
+          LabeledNumberField(
+            title: "Night Multiplier",
+            subtitle: "ರಾತ್ರಿ ಗುಣಕ",
+            value: $nightMultiplier
+          )
+          Stepper("Start Hour: \(nightStartHour):00", value: $nightStartHour, in: 0...23)
+          Stepper("End Hour: \(nightEndHour):00", value: $nightEndHour, in: 0...23)
+        }
+      }
+      .scrollContentBackground(.hidden)
+    }
+    .navigationTitle("Add Fare")
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItem(placement: .cancellationAction) {
+        Button("Cancel") { dismiss() }
+      }
+      ToolbarItem(placement: .confirmationAction) {
+        Button("Save") { save() }
+      }
+      ToolbarItem(placement: .principal) {
+        VStack(spacing: 2) {
+          Text("Add Fare")
+            .font(.nammaDisplay(16))
+          Text(cityName)
+            .font(.nammaBody(11))
+        }
+      }
+    }
+  }
+
+  private func save() {
+    let profile = CityFareProfile(
+      id: UUID().uuidString,
+      cityId: cityId,
+      name: cityName,
+      cityKey: CityKey(city: cityName, region: nil, countryCode: "IN"),
+      rates: FareRates(
+        baseFare: baseFare,
+        perKmRate: perKmRate,
+        perMinuteRate: 0,
+        includedKm: includedKm,
+        minFare: minFare
+      ),
+      multipliers: FareMultipliers(night: nightMultiplier),
+      nightWindow: NightFareWindow(startHour: nightStartHour, endHour: nightEndHour),
+      waitCharges: WaitingChargePolicy(
+        freeWaitMinutes: freeWaitMinutes,
+        waitIntervalMinutes: waitIntervalMinutes,
+        waitIntervalCharge: waitIntervalCharge
+      ),
+      effectiveFrom: effectiveFrom
+    )
+
+    if isNewCity {
+      settingsStore.addCity(profile)
+    } else {
+      settingsStore.addFareProfile(profile)
+    }
+    dismiss()
+  }
+}
+
+#Preview {
+  NavigationStack {
+    AddFareView(cityId: "test-city", cityName: "Test City")
+      .environment(SettingsStore())
+  }
+}

--- a/NammaMeter/CityDetailView.swift
+++ b/NammaMeter/CityDetailView.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+
+struct CityDetailView: View {
+  @Environment(SettingsStore.self) private var settingsStore
+  @Environment(MeterStore.self) private var meterStore
+  let cityId: String
+
+  private var canEditSettings: Bool {
+    meterStore.tripState == .forHire
+  }
+
+  private var fareProfiles: [CityFareProfile] {
+    settingsStore.fareProfiles(for: cityId)
+  }
+
+  private var cityName: String {
+    fareProfiles.first?.name ?? cityId
+  }
+
+  var body: some View {
+    ZStack {
+      NammaBackground()
+      List {
+        ForEach(fareProfiles) { profile in
+          FareCardRow(profile: profile)
+        }
+        .onDelete(perform: deleteFareCards)
+
+        NavigationLink(destination: AddFareView(cityId: cityId, cityName: cityName)) {
+          HStack {
+            Image(systemName: "plus.circle.fill")
+              .foregroundStyle(Theme.ink)
+            VStack(alignment: .leading, spacing: 2) {
+              Text("Add Fare Card")
+                .font(.nammaDisplay(14))
+              Text("ಬಾಡಿಗೆ ಕಾರ್ಡ್ ಸೇರಿಸಿ")
+                .font(.nammaBody(11))
+                .foregroundStyle(.secondary)
+            }
+          }
+        }
+        .disabled(!canEditSettings)
+        .opacity(canEditSettings ? 1 : 0.5)
+      }
+      .scrollContentBackground(.hidden)
+    }
+    .navigationTitle(cityName)
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItem(placement: .principal) {
+        VStack(spacing: 2) {
+          Text(cityName)
+            .font(.nammaDisplay(16))
+          Text("\(fareProfiles.count) fare card\(fareProfiles.count == 1 ? "" : "s")")
+            .font(.nammaBody(11))
+        }
+      }
+    }
+  }
+
+  private func deleteFareCards(at offsets: IndexSet) {
+    guard canEditSettings else { return }
+    for offset in offsets {
+      settingsStore.deleteFareProfile(fareProfiles[offset].id)
+    }
+  }
+}
+
+struct FareCardRow: View {
+  let profile: CityFareProfile
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("Effective: \(profile.effectiveFrom.formatted(date: .abbreviated, time: .omitted))")
+        .font(.nammaBody(11))
+        .foregroundStyle(.secondary)
+
+      VStack(alignment: .leading, spacing: 4) {
+        HStack(spacing: 12) {
+          FareDetail(label: "Base", value: profile.rates.baseFare)
+          FareDetail(label: "Per Km", value: profile.rates.perKmRate)
+          FareDetail(label: "Min", value: profile.rates.minFare)
+        }
+
+        HStack(spacing: 12) {
+          FareDetail(label: "Free Wait", value: profile.waitCharges.freeWaitMinutes, unit: "min")
+          FareDetail(label: "Interval", value: profile.waitCharges.waitIntervalMinutes, unit: "min")
+          FareDetail(label: "Per Int.", value: profile.waitCharges.waitIntervalCharge)
+        }
+
+        HStack(spacing: 12) {
+          FareDetail(label: "Night ×", value: profile.multipliers.night, isCurrency: false)
+          Text("(\(profile.nightWindow.startHour):00 - \(profile.nightWindow.endHour):00)")
+            .font(.nammaBody(10))
+            .foregroundStyle(.secondary)
+        }
+      }
+    }
+    .padding(.vertical, 4)
+  }
+}
+
+struct FareDetail: View {
+  let label: String
+  let value: Double
+  var unit: String? = nil
+  var isCurrency: Bool = true
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 1) {
+      Text(label)
+        .font(.nammaBody(9))
+        .foregroundStyle(.tertiary)
+      if isCurrency {
+        Text("₹\(value, specifier: "%.0f")\(unit ?? "")")
+          .font(.nammaBody(12))
+      } else {
+        Text("\(value, specifier: "%.1f")\(unit ?? "")")
+          .font(.nammaBody(12))
+      }
+    }
+  }
+}
+
+#Preview {
+  NavigationStack {
+    CityDetailView(cityId: "bengaluru")
+      .environment(SettingsStore())
+      .environment(MeterStore())
+  }
+}

--- a/NammaMeter/CityManagementView.swift
+++ b/NammaMeter/CityManagementView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+struct CityManagementView: View {
+  @Environment(SettingsStore.self) private var settingsStore
+  @Environment(MeterStore.self) private var meterStore
+  @State private var cityToDelete: CityFareProfile?
+  @State private var showDeleteConfirmation = false
+
+  private var canEditSettings: Bool {
+    meterStore.tripState == .forHire
+  }
+
+  var body: some View {
+    ZStack {
+      NammaBackground()
+      List {
+        ForEach(settingsStore.availableCities) { city in
+          NavigationLink(destination: CityDetailView(cityId: city.cityId)) {
+            CityRow(city: city, isSelected: settingsStore.selectedCityId == city.cityId)
+          }
+        }
+        .onDelete(perform: deleteCities)
+
+        NavigationLink(destination: AddCityView()) {
+          HStack {
+            Image(systemName: "plus.circle.fill")
+              .foregroundStyle(Theme.ink)
+            VStack(alignment: .leading, spacing: 2) {
+              Text("Add City")
+                .font(.nammaDisplay(14))
+              Text("ನಗರವನ್ನು ಸೇರಿಸಿ")
+                .font(.nammaBody(11))
+                .foregroundStyle(.secondary)
+            }
+          }
+        }
+        .disabled(!canEditSettings)
+        .opacity(canEditSettings ? 1 : 0.5)
+      }
+      .scrollContentBackground(.hidden)
+    }
+    .navigationTitle("Manage Cities")
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItem(placement: .principal) {
+        VStack(spacing: 2) {
+          Text("Manage Cities")
+            .font(.nammaDisplay(16))
+          Text("ನಗರಗಳನ್ನು ನಿರ್ವಹಿಸಿ")
+            .font(.nammaBody(11))
+        }
+      }
+    }
+    .alert("Delete City?", isPresented: $showDeleteConfirmation) {
+      Button("Cancel", role: .cancel) {
+        cityToDelete = nil
+      }
+      Button("Delete", role: .destructive) {
+        if let city = cityToDelete {
+          settingsStore.deleteCity(city.cityId)
+        }
+        cityToDelete = nil
+      }
+    } message: {
+      if let city = cityToDelete {
+        let count = settingsStore.fareProfiles(for: city.cityId).count
+        Text("This will delete \(city.name) and its \(count) fare card\(count == 1 ? "" : "s").")
+      }
+    }
+  }
+
+  private func deleteCities(at offsets: IndexSet) {
+    guard canEditSettings else { return }
+    for offset in offsets {
+      let city = settingsStore.availableCities[offset]
+      let fareCount = settingsStore.fareProfiles(for: city.cityId).count
+      if fareCount > 0 {
+        cityToDelete = city
+        showDeleteConfirmation = true
+      } else {
+        settingsStore.deleteCity(city.cityId)
+      }
+    }
+  }
+}
+
+struct CityRow: View {
+  let city: CityFareProfile
+  let isSelected: Bool
+
+  var body: some View {
+    HStack {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(city.name)
+          .font(.nammaDisplay(14))
+        if let region = city.cityKey.region {
+          Text(region)
+            .font(.nammaBody(11))
+            .foregroundStyle(.secondary)
+        }
+        HStack(spacing: 8) {
+          Text("Base: ₹\(city.rates.baseFare, specifier: "%.0f")")
+          Text("Per Km: ₹\(city.rates.perKmRate, specifier: "%.0f")")
+        }
+        .font(.nammaBody(10))
+        .foregroundStyle(.secondary)
+      }
+      Spacer()
+      if isSelected {
+        Image(systemName: "checkmark.circle.fill")
+          .foregroundStyle(Theme.ink)
+      }
+    }
+  }
+}
+
+#Preview {
+  NavigationStack {
+    CityManagementView()
+      .environment(SettingsStore())
+      .environment(MeterStore())
+  }
+}

--- a/NammaMeter/SettingsStore.swift
+++ b/NammaMeter/SettingsStore.swift
@@ -78,6 +78,52 @@ final class SettingsStore {
     scheduleSave()
   }
 
+  func addFareProfile(_ profile: CityFareProfile) {
+    state.profiles.append(profile)
+    scheduleSave()
+  }
+
+  func deleteFareProfile(_ profileId: String) {
+    state.profiles.removeAll { $0.id == profileId }
+
+    if let selectedId = state.selectedCityId,
+       !state.profiles.contains(where: { $0.cityId == selectedId }) {
+      fallbackToDefaultCity()
+    }
+    scheduleSave()
+  }
+
+  func deleteCity(_ cityId: String) {
+    state.profiles.removeAll { $0.cityId == cityId }
+
+    if state.selectedCityId == cityId {
+      fallbackToDefaultCity()
+    }
+    scheduleSave()
+  }
+
+  private func fallbackToDefaultCity() {
+    if state.profiles.contains(where: { $0.cityId == FareCatalog.defaultCityId }) {
+      state.selectedCityId = FareCatalog.defaultCityId
+    } else if let first = state.profiles.first {
+      state.selectedCityId = first.cityId
+    } else {
+      state.profiles = [FareCatalog.defaultProfile]
+      state.selectedCityId = FareCatalog.defaultCityId
+    }
+    syncSettingsFromActiveProfile()
+  }
+
+  func fareProfiles(for cityId: String) -> [CityFareProfile] {
+    state.profiles
+      .filter { $0.cityId == cityId }
+      .sorted { $0.effectiveFrom > $1.effectiveFrom }
+  }
+
+  func isCatalogCity(_ cityId: String) -> Bool {
+    FareCatalog.entries.contains { $0.profile.cityId == cityId }
+  }
+
   var activeCityInfo: (cityId: String, cityName: String) {
     let cityId = effectiveCityId
     let profile = activeProfile(for: cityId, on: Date()) ?? FareCatalog.defaultProfile

--- a/NammaMeter/SettingsView.swift
+++ b/NammaMeter/SettingsView.swift
@@ -10,7 +10,6 @@ struct SettingsView: View {
   }
 
   var body: some View {
-    @Bindable var settingsStore = settingsStore
     NavigationStack {
       ZStack {
         NammaBackground()
@@ -27,40 +26,25 @@ struct SettingsView: View {
           }
 
           Section(header: SectionHeader(title: "City", subtitle: "ನಗರ")) {
-            ForEach(settingsStore.availableCities) { city in
-              Button {
-                settingsStore.selectCity(city.cityId)
-              } label: {
-                HStack {
-                  VStack(alignment: .leading, spacing: 2) {
-                    Text(city.name)
-                      .font(.nammaDisplay(14))
-                    if let region = city.cityKey.region {
-                      Text(region)
-                        .font(.nammaBody(11))
-                        .foregroundStyle(.secondary)
-                    }
-                  }
-                  Spacer()
-                  if settingsStore.selectedCityId == city.cityId {
-                    Image(systemName: "checkmark")
-                      .foregroundStyle(Theme.ink)
-                  }
-                }
+            Picker("City", selection: Binding(
+              get: { settingsStore.selectedCityId ?? "" },
+              set: { settingsStore.selectCity($0) }
+            )) {
+              ForEach(settingsStore.availableCities) { city in
+                Text(city.name).tag(city.cityId)
               }
-              .buttonStyle(.plain)
-              .disabled(!canEditSettings)
-              .opacity(canEditSettings ? 1 : 0.5)
             }
+            .pickerStyle(.menu)
+            .disabled(!canEditSettings)
 
-            NavigationLink(destination: AddCityView()) {
+            NavigationLink(destination: CityManagementView()) {
               HStack {
-                Image(systemName: "plus.circle.fill")
+                Image(systemName: "building.2")
                   .foregroundStyle(Theme.ink)
                 VStack(alignment: .leading, spacing: 2) {
-                  Text("Add City")
+                  Text("Manage Cities")
                     .font(.nammaDisplay(14))
-                  Text("ನಗರವನ್ನು ಸೇರಿಸಿ")
+                  Text("ನಗರಗಳನ್ನು ನಿರ್ವಹಿಸಿ")
                     .font(.nammaBody(11))
                     .foregroundStyle(.secondary)
                 }
@@ -71,46 +55,46 @@ struct SettingsView: View {
           }
 
           Section(header: SectionHeader(title: "Rates", subtitle: "ದರಗಳು")) {
-            LabeledNumberField(
+            LabeledValue(
               title: "Base Fare",
               subtitle: "ಮೂಲ ಬಾಡಿಗೆ",
-              value: $settingsStore.settings.baseFare
+              value: settingsStore.settings.baseFare
             )
-            LabeledNumberField(
+            LabeledValue(
               title: "Per Km",
               subtitle: "ಪ್ರತಿ ಕಿಲೋ ಮೀಟರ್",
-              value: $settingsStore.settings.perKmRate
+              value: settingsStore.settings.perKmRate
             )
-            LabeledNumberField(
+            LabeledValue(
               title: "Minimum Fare",
               subtitle: "ಕನಿಷ್ಠ ಬಾಡಿಗೆ",
-              value: $settingsStore.settings.minFare
+              value: settingsStore.settings.minFare
             )
           }
 
           Section(header: SectionHeader(title: "Waiting Charges", subtitle: "ನಿಲ್ಲಿಕೆ ಶುಲ್ಕಗಳು")) {
-            LabeledNumberField(
+            LabeledValue(
               title: "Free Wait (min)",
               subtitle: "ಉಚಿತ ನಿಲ್ಲಿಕೆ (ನಿಮಿಷ)",
-              value: $settingsStore.settings.freeWaitMinutes
+              value: settingsStore.settings.freeWaitMinutes
             )
-            LabeledNumberField(
+            LabeledValue(
               title: "Interval (min)",
               subtitle: "ಮಧ್ಯಂತರ (ನಿಮಿಷ)",
-              value: $settingsStore.settings.waitIntervalMinutes
+              value: settingsStore.settings.waitIntervalMinutes
             )
-            LabeledNumberField(
+            LabeledValue(
               title: "Per Interval",
               subtitle: "ಪ್ರತಿ ಮಧ್ಯಂತರ",
-              value: $settingsStore.settings.waitIntervalCharge
+              value: settingsStore.settings.waitIntervalCharge
             )
           }
 
           Section(header: SectionHeader(title: "Modifiers", subtitle: "ಗುಣಕಗಳು")) {
-            LabeledNumberField(
+            LabeledValue(
               title: "Night Multiplier",
               subtitle: "ರಾತ್ರಿ ಗುಣಕ",
-              value: $settingsStore.settings.nightMultiplier
+              value: settingsStore.settings.nightMultiplier
             )
           }
 
@@ -164,6 +148,26 @@ struct LabeledNumberField: View {
       TextField("", value: $value, format: .number.precision(.fractionLength(2)))
         .keyboardType(.decimalPad)
         .multilineTextAlignment(.trailing)
+    } label: {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title)
+        Text(subtitle)
+          .font(.nammaBody(11))
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+}
+
+struct LabeledValue: View {
+  let title: String
+  let subtitle: String
+  let value: Double
+
+  var body: some View {
+    LabeledContent {
+      Text(value, format: .number.precision(.fractionLength(2)))
+        .foregroundStyle(.secondary)
     } label: {
       VStack(alignment: .leading, spacing: 2) {
         Text(title)


### PR DESCRIPTION
## Summary
- Replace city button list with compact dropdown picker in Settings
- Add dedicated city and fare card management pages
- Make fare information read-only in settings (editing via management UI only)
- Support future effective dates for fare cards

## Changes

**Settings Page**
- City selection now uses a compact dropdown picker instead of a list of buttons
- Added "Manage Cities" navigation link to access city management
- Fare rates displayed as read-only labels (no longer editable inline)

**City Management (`CityManagementView`)**
- List all cities with fare summary (base fare, per km)
- Swipe-to-delete cities with confirmation dialog if city has fare cards
- Navigation to city detail view and add city flow

**City Detail (`CityDetailView`)**
- View all fare cards for a city sorted by effective date
- Swipe-to-delete individual fare cards
- Add new fare cards with future effective dates

**Add City Flow (2-step)**
- Step 1: Enter city name (`AddCityView`)
- Step 2: Configure fare details (`AddFareView`)

**Add Fare (`AddFareView`)**
- New standalone view for adding fare cards
- Supports setting effective date (defaults to today, can be future)
- Reused for both new cities and adding fares to existing cities

**SettingsStore**
- `addFareProfile()` - Add fare card without changing selection
- `deleteFareProfile()` - Delete specific fare card by ID
- `deleteCity()` - Delete all fare cards for a city
- `fareProfiles(for:)` - Get all fare cards for a city
- `isCatalogCity()` - Check if city is from preset catalog

## Test plan
- [x] Verify city dropdown works in Settings tab
- [x] Verify "Manage Cities" navigates to city list
- [x] Verify tapping a city shows its fare cards
- [x] Verify swipe-to-delete works for fare cards
- [x] Verify swipe-to-delete works for cities (with confirmation if has fare cards)
- [x] Verify 2-step add city flow (name → fare details)
- [x] Verify effective date picker allows future dates
- [x] Verify all existing tests pass

Closes #34

🤖 Generated with [Claude Code](https://claude.ai/code)