### PR TITLE
Remove stray merge marker from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # Conductor workspace scratch space
 .context/
 


### PR DESCRIPTION
## Summary
- Removed an unresolved merge conflict marker from `.gitignore`.
- Preserved existing ignore entries.

## Testing
- Not run (non-code change).
