### PR TITLE
Add MeterShell to consolidate meter view geometry and case rendering

### DIFF
--- a/NammaMeter/BrightDigitalMeterView.swift
+++ b/NammaMeter/BrightDigitalMeterView.swift
@@ -9,18 +9,11 @@ struct BrightDigitalFullMeterPanel: View {
   let distanceMeters: Double
   let topInset: CGFloat
 
-  private let caseTop = Color(red: 0.14, green: 0.15, blue: 0.16)
-  private let caseBottom = Color(red: 0.05, green: 0.05, blue: 0.06)
   private let faceTop = Color(red: 0.2, green: 0.21, blue: 0.22)
   private let faceBottom = Color(red: 0.1, green: 0.1, blue: 0.11)
 
   var body: some View {
-    GeometryReader { geo in
-      let desiredWidth = geo.size.width * BrightDigitalDimensions.widthRatio
-      let bodyHeightForWidth = desiredWidth * BrightDigitalDimensions.bodyAspect
-      let scale = min(1, geo.size.height / bodyHeightForWidth)
-      let bodyWidth = desiredWidth * scale
-      let bodyHeight = bodyHeightForWidth * scale
+    MeterShell(style: .brightDigital, topInset: topInset) { bodyWidth, bodyHeight in
       let faceWidth = bodyWidth * 0.92
       let faceHeight = bodyHeight * 0.86
       let windowWidth = faceWidth * 0.92
@@ -29,20 +22,6 @@ struct BrightDigitalFullMeterPanel: View {
       let badgeHeight = faceHeight * 0.14
 
       ZStack {
-        RoundedRectangle(cornerRadius: bodyWidth * 0.08, style: .continuous)
-          .fill(
-            LinearGradient(
-              colors: [caseTop, caseBottom],
-              startPoint: .topLeading,
-              endPoint: .bottomTrailing
-            )
-          )
-          .overlay(
-            RoundedRectangle(cornerRadius: bodyWidth * 0.08, style: .continuous)
-              .stroke(Color.white.opacity(0.08), lineWidth: 1.2)
-          )
-          .shadow(color: Color.black.opacity(0.4), radius: 16, x: 0, y: 10)
-
         RoundedRectangle(cornerRadius: bodyWidth * 0.06, style: .continuous)
           .fill(
             LinearGradient(
@@ -73,9 +52,6 @@ struct BrightDigitalFullMeterPanel: View {
         }
         .frame(width: faceWidth, height: faceHeight)
       }
-      .frame(width: bodyWidth, height: bodyHeight)
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-      .offset(y: topInset)
     }
   }
 }

--- a/NammaMeter/DigitalMeterView.swift
+++ b/NammaMeter/DigitalMeterView.swift
@@ -7,48 +7,23 @@ struct DigitalFullMeterPanel: View {
   let fare: Double
   @State private var glowPulse = false
 
-  private let bodyColor = Color(red: 0.09, green: 0.1, blue: 0.12)
   private let bezel = Color(red: 0.18, green: 0.2, blue: 0.24)
   private let accent = Color(red: 0.15, green: 0.8, blue: 0.9)
 
   var body: some View {
-    GeometryReader { geo in
-      let desiredWidth = geo.size.width * 0.78
-      let bodyHeightForWidth = desiredWidth * 0.7
-      let scale = min(1, geo.size.height / bodyHeightForWidth)
-      let bodyWidth = desiredWidth * scale
-      let bodyHeight = bodyHeightForWidth * scale
+    MeterShell(style: .digital) { bodyWidth, bodyHeight in
+      VStack(spacing: bodyHeight * 0.08) {
+        Text("DIGITAL FARE METER")
+          .font(.system(size: bodyWidth * 0.05, weight: .semibold, design: .rounded))
+          .foregroundStyle(Color.white.opacity(0.7))
 
-      ZStack {
-        RoundedRectangle(cornerRadius: bodyWidth * 0.08, style: .continuous)
-          .fill(
-            LinearGradient(
-              colors: [bodyColor, Color.black],
-              startPoint: .topLeading,
-              endPoint: .bottomTrailing
-            )
-          )
-          .overlay(
-            RoundedRectangle(cornerRadius: bodyWidth * 0.08, style: .continuous)
-              .stroke(Color.white.opacity(0.08), lineWidth: 1)
-          )
-          .shadow(color: Color.black.opacity(0.4), radius: 14, x: 0, y: 8)
+        DigitalMeterScreen(tripState: tripState, fare: fare, glow: glowPulse, accent: accent, bezel: bezel)
+          .frame(height: bodyHeight * 0.32)
 
-        VStack(spacing: bodyHeight * 0.08) {
-          Text("DIGITAL FARE METER")
-            .font(.system(size: bodyWidth * 0.05, weight: .semibold, design: .rounded))
-            .foregroundStyle(Color.white.opacity(0.7))
-
-          DigitalMeterScreen(tripState: tripState, fare: fare, glow: glowPulse, accent: accent, bezel: bezel)
-            .frame(height: bodyHeight * 0.32)
-
-          DigitalButtonRow(width: bodyWidth)
-        }
-        .padding(.horizontal, bodyWidth * 0.12)
-        .padding(.vertical, bodyHeight * 0.12)
+        DigitalButtonRow(width: bodyWidth)
       }
-      .frame(width: bodyWidth, height: bodyHeight)
-      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .padding(.horizontal, bodyWidth * 0.12)
+      .padding(.vertical, bodyHeight * 0.12)
     }
     .onAppear {
       withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {

--- a/NammaMeter/GoldenEagleMeterView.swift
+++ b/NammaMeter/GoldenEagleMeterView.swift
@@ -10,64 +10,31 @@ struct GoldenEagleFullMeterPanel: View {
   let isNight: Bool
   let topInset: CGFloat
 
-  private let caseLight = Color(red: 0.78, green: 0.78, blue: 0.76)
-  private let caseMid = Color(red: 0.6, green: 0.6, blue: 0.58)
-  private let caseDark = Color(red: 0.36, green: 0.36, blue: 0.35)
-  private let faceTop = Color(red: 0.68, green: 0.69, blue: 0.66)
-  private let faceBottom = Color(red: 0.48, green: 0.49, blue: 0.47)
-
   var body: some View {
-    GeometryReader { geo in
-      let desiredWidth = geo.size.width * GoldenEagleDimensions.widthRatio
-      let bodyHeightForWidth = desiredWidth * GoldenEagleDimensions.bodyAspect
-      let scale = min(1, geo.size.height / bodyHeightForWidth)
-      let bodyWidth = desiredWidth * scale
-      let bodyHeight = bodyHeightForWidth * scale
+    MeterShell(style: .goldenEagle, topInset: topInset) { bodyWidth, bodyHeight in
+      VStack(spacing: 0) {
+        Spacer()
 
-      ZStack {
-        // Layer 1: Outer case - the gray plastic housing of the meter
-        RoundedRectangle(cornerRadius: bodyWidth * 0.08, style: .continuous)
-          .fill(
-            LinearGradient(
-              colors: [caseLight, caseMid, caseDark],
-              startPoint: .topLeading,
-              endPoint: .bottomTrailing
-            )
-          )
-          .overlay(
-            RoundedRectangle(cornerRadius: bodyWidth * 0.08, style: .continuous)
-              .stroke(Color.white.opacity(0.4), lineWidth: 1.2)
-          )
-          .shadow(color: Color.black.opacity(0.35), radius: 16, x: 0, y: 10)
+        // Display dial - shows fare, distance, wait time with LED segments
+        GoldenEagleDisplayWindow(
+          tripState: tripState,
+          fare: fare,
+          waitingDuration: waitingDuration,
+          distanceKm: distanceMeters / 1000,
+          isNight: isNight,
+          width: bodyWidth * 0.90,
+          height: bodyHeight * 0.70
+        )
 
-        // Layer 2: Content - display window and manufacturer plate
-        VStack(spacing: 0) {
-          Spacer()
+        // Spacer to push manufacturer plate to center of remaining space
+        Spacer()
 
-          // Display dial - shows fare, distance, wait time with LED segments
-          GoldenEagleDisplayWindow(
-            tripState: tripState,
-            fare: fare,
-            waitingDuration: waitingDuration,
-            distanceKm: distanceMeters / 1000,
-            isNight: isNight,
-            width: bodyWidth * 0.90,
-            height: bodyHeight * 0.70
-          )
+        // Manufacturer plate - shows company info at bottom
+        GoldenEagleManufacturerPlate(width: bodyWidth * 0.90, height: bodyHeight * 0.18)
 
-          // Spacer to push manufacturer plate to center of remaining space
-          Spacer()
-
-          // Manufacturer plate - shows company info at bottom
-          GoldenEagleManufacturerPlate(width: bodyWidth * 0.90, height: bodyHeight * 0.18)
-
-          // Equal spacer below to center the plate
-          Spacer()
-        }
+        // Equal spacer below to center the plate
+        Spacer()
       }
-      .frame(width: bodyWidth, height: bodyHeight)
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-      .offset(y: topInset)
     }
   }
 }

--- a/NammaMeter/MeterTypes.swift
+++ b/NammaMeter/MeterTypes.swift
@@ -185,6 +185,161 @@ enum BrightDigitalDimensions {
   }
 }
 
+// MARK: - Digital Meter Dimensions
+
+/// Dimension ratios for the Neo Digital meter
+enum DigitalDimensions {
+  static let widthRatio: CGFloat = 0.78
+  static let bodyAspect: CGFloat = 0.7
+
+  static func naturalHeight(for containerWidth: CGFloat) -> CGFloat {
+    containerWidth * widthRatio * bodyAspect
+  }
+}
+
+// MARK: - Meter Shell Style
+
+/// Configuration for meter shell appearance
+struct MeterShellStyle {
+  let widthRatio: CGFloat
+  let bodyAspect: CGFloat
+  let cornerRadiusRatio: CGFloat
+  let bodyGradientColors: [Color]
+  let strokeOpacity: Double
+  let strokeLineWidth: CGFloat
+  let shadowOpacity: Double
+  let shadowRadius: CGFloat
+  let shadowYOffset: CGFloat
+  let alignment: Alignment
+}
+
+extension MeterShellStyle {
+  static let superMechanical = MeterShellStyle(
+    widthRatio: SuperMeterDimensions.widthRatio,
+    bodyAspect: SuperMeterDimensions.bodyAspect,
+    cornerRadiusRatio: 0.08,
+    bodyGradientColors: [Color(red: 0.17, green: 0.18, blue: 0.19), Color(red: 0.06, green: 0.06, blue: 0.07)],
+    strokeOpacity: 0.08,
+    strokeLineWidth: 1.2,
+    shadowOpacity: 0.35,
+    shadowRadius: 16,
+    shadowYOffset: 10,
+    alignment: .top
+  )
+
+  static let superElectronic = MeterShellStyle(
+    widthRatio: SuperElectronicDimensions.widthRatio,
+    bodyAspect: SuperElectronicDimensions.bodyAspect,
+    cornerRadiusRatio: 0.08,
+    bodyGradientColors: [Color(red: 0.17, green: 0.18, blue: 0.19), Color(red: 0.06, green: 0.06, blue: 0.07)],
+    strokeOpacity: 0.08,
+    strokeLineWidth: 1.2,
+    shadowOpacity: 0.35,
+    shadowRadius: 16,
+    shadowYOffset: 10,
+    alignment: .top
+  )
+
+  static let goldenEagle = MeterShellStyle(
+    widthRatio: GoldenEagleDimensions.widthRatio,
+    bodyAspect: GoldenEagleDimensions.bodyAspect,
+    cornerRadiusRatio: 0.08,
+    bodyGradientColors: [
+      Color(red: 0.78, green: 0.78, blue: 0.76),
+      Color(red: 0.6, green: 0.6, blue: 0.58),
+      Color(red: 0.36, green: 0.36, blue: 0.35)
+    ],
+    strokeOpacity: 0.4,
+    strokeLineWidth: 1.2,
+    shadowOpacity: 0.35,
+    shadowRadius: 16,
+    shadowYOffset: 10,
+    alignment: .top
+  )
+
+  static let brightDigital = MeterShellStyle(
+    widthRatio: BrightDigitalDimensions.widthRatio,
+    bodyAspect: BrightDigitalDimensions.bodyAspect,
+    cornerRadiusRatio: 0.08,
+    bodyGradientColors: [Color(red: 0.14, green: 0.15, blue: 0.16), Color(red: 0.05, green: 0.05, blue: 0.06)],
+    strokeOpacity: 0.08,
+    strokeLineWidth: 1.2,
+    shadowOpacity: 0.4,
+    shadowRadius: 16,
+    shadowYOffset: 10,
+    alignment: .top
+  )
+
+  static let digital = MeterShellStyle(
+    widthRatio: DigitalDimensions.widthRatio,
+    bodyAspect: DigitalDimensions.bodyAspect,
+    cornerRadiusRatio: 0.08,
+    bodyGradientColors: [Color(red: 0.09, green: 0.1, blue: 0.12), .black],
+    strokeOpacity: 0.08,
+    strokeLineWidth: 1,
+    shadowOpacity: 0.4,
+    shadowRadius: 14,
+    shadowYOffset: 8,
+    alignment: .center
+  )
+}
+
+// MARK: - Meter Shell
+
+/// Container that handles geometry scaling and shell rendering for meter panels
+struct MeterShell<Content: View>: View {
+  let style: MeterShellStyle
+  let topInset: CGFloat
+  @ViewBuilder let content: (_ bodyWidth: CGFloat, _ bodyHeight: CGFloat) -> Content
+
+  init(
+    style: MeterShellStyle,
+    topInset: CGFloat = 0,
+    @ViewBuilder content: @escaping (_ bodyWidth: CGFloat, _ bodyHeight: CGFloat) -> Content
+  ) {
+    self.style = style
+    self.topInset = topInset
+    self.content = content
+  }
+
+  var body: some View {
+    GeometryReader { geo in
+      let desiredWidth = geo.size.width * style.widthRatio
+      let bodyHeightForWidth = desiredWidth * style.bodyAspect
+      let scale = min(1, geo.size.height / bodyHeightForWidth)
+      let bodyWidth = desiredWidth * scale
+      let bodyHeight = bodyHeightForWidth * scale
+      let cornerRadius = bodyWidth * style.cornerRadiusRatio
+
+      ZStack {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+          .fill(
+            LinearGradient(
+              colors: style.bodyGradientColors,
+              startPoint: .topLeading,
+              endPoint: .bottomTrailing
+            )
+          )
+          .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+              .stroke(Color.white.opacity(style.strokeOpacity), lineWidth: style.strokeLineWidth)
+          )
+          .shadow(
+            color: .black.opacity(style.shadowOpacity),
+            radius: style.shadowRadius,
+            x: 0,
+            y: style.shadowYOffset
+          )
+
+        content(bodyWidth, bodyHeight)
+      }
+      .frame(width: bodyWidth, height: bodyHeight)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: style.alignment)
+      .offset(y: style.alignment == .top ? topInset : 0)
+    }
+  }
+}
+
 // MARK: - Safe Area Insets Helper
 
 @MainActor

--- a/NammaMeter/SuperElectronicMeterView.swift
+++ b/NammaMeter/SuperElectronicMeterView.swift
@@ -10,63 +10,35 @@ struct SuperElectronicFullMeterPanel: View {
   let isNight: Bool
   let topInset: CGFloat
 
-  private let caseTop = Color(red: 0.17, green: 0.18, blue: 0.19)
-  private let caseBottom = Color(red: 0.06, green: 0.06, blue: 0.07)
   private let metalPanel = Color(red: 0.88, green: 0.87, blue: 0.85)
   private let metalEdge = Color(red: 0.7, green: 0.7, blue: 0.68)
 
   var body: some View {
-    GeometryReader { geo in
-      let desiredBodyWidth = geo.size.width * SuperElectronicDimensions.widthRatio
-      let bodyHeightForWidth = desiredBodyWidth * SuperElectronicDimensions.bodyAspect
-      let scale = min(1, geo.size.height / bodyHeightForWidth)
-      let bodyWidth = desiredBodyWidth * scale
-      let bodyHeight = bodyHeightForWidth * scale
+    MeterShell(style: .superElectronic, topInset: topInset) { bodyWidth, bodyHeight in
+      VStack(spacing: bodyHeight * 0.02) {
+        // Top brand plate
+        SuperElectronicBrandPlate(width: bodyWidth * 0.85, height: bodyHeight * 0.08)
 
-      ZStack {
-        // Main body
-        RoundedRectangle(cornerRadius: bodyWidth * 0.08, style: .continuous)
-          .fill(
-            LinearGradient(
-              colors: [caseTop, caseBottom],
-              startPoint: .topLeading,
-              endPoint: .bottomTrailing
-            )
-          )
-          .overlay(
-            RoundedRectangle(cornerRadius: bodyWidth * 0.08, style: .continuous)
-              .stroke(Color.white.opacity(0.08), lineWidth: 1.2)
-          )
-          .shadow(color: Color.black.opacity(0.35), radius: 16, x: 0, y: 10)
+        // Main LED display area
+        SuperElectronicLEDDisplay(
+          tripState: tripState,
+          fare: fare,
+          waitingDuration: waitingDuration,
+          distanceKm: distanceMeters / 1000,
+          isNight: isNight,
+          width: bodyWidth * 0.88,
+          height: bodyHeight * 0.52
+        )
 
-        VStack(spacing: bodyHeight * 0.02) {
-          // Top brand plate
-          SuperElectronicBrandPlate(width: bodyWidth * 0.85, height: bodyHeight * 0.08)
-
-          // Main LED display area
-          SuperElectronicLEDDisplay(
-            tripState: tripState,
-            fare: fare,
-            waitingDuration: waitingDuration,
-            distanceKm: distanceMeters / 1000,
-            isNight: isNight,
-            width: bodyWidth * 0.88,
-            height: bodyHeight * 0.52
-          )
-
-          // Bottom manufacturer plate
-          SuperElectronicManufacturerPlate(
-            width: bodyWidth * 0.85,
-            height: bodyHeight * 0.14,
-            metalPanel: metalPanel,
-            metalEdge: metalEdge
-          )
-        }
-        .padding(.vertical, bodyHeight * 0.06)
+        // Bottom manufacturer plate
+        SuperElectronicManufacturerPlate(
+          width: bodyWidth * 0.85,
+          height: bodyHeight * 0.14,
+          metalPanel: metalPanel,
+          metalEdge: metalEdge
+        )
       }
-      .frame(width: bodyWidth, height: bodyHeight)
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-      .offset(y: topInset)
+      .padding(.vertical, bodyHeight * 0.06)
     }
   }
 }


### PR DESCRIPTION
## Summary

- Introduces `MeterShell<Content>` generic view to encapsulate shared geometry scaling and case rendering logic
- Adds `MeterShellStyle` configuration struct with presets for all 5 meter types
- Refactors 4 meter views to use `MeterShell`, reducing code duplication

## Problem

The meter display views repeated similar layout calculations and case rendering logic:
- GeometryReader + scale calculation (~15 lines each)
- RoundedRectangle with gradient fill, stroke overlay, and shadow
- Frame and alignment configuration

This duplication made maintenance difficult and required updates in multiple places.

## Changes

| File | Change |
|------|--------|
| `MeterTypes.swift` | Add `DigitalDimensions`, `MeterShellStyle`, `MeterShell<Content>` (+155 lines) |
| `DigitalMeterView.swift` | Use `MeterShell` (-25 lines) |
| `BrightDigitalMeterView.swift` | Use `MeterShell` (-26 lines) |
| `GoldenEagleMeterView.swift` | Use `MeterShell` (-38 lines) |
| `SuperElectronicMeterView.swift` | Use `MeterShell` (-29 lines) |

**Note:** `SuperMechanicalMeterView` is unchanged - its 3-part structure (canopy + body + base) with negative spacing for overlap is fundamentally different from the simple shell pattern.

## Test plan

- [x] All 94 unit tests pass
- [x] All 15 snapshot tests pass (confirming visual parity)
- [x] Manually tested app - all meter styles render correctly
- [x] Tested meter style switching via settings
- [x] Tested Full vs Display render modes

Fixes #41 (Phase 1)
Related: #53 (Phase 2 - display row composition, future work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)