### PR TITLE
Test refactor: consolidate shared helpers

### DIFF
--- a/NammaMeterTests/FareProfileTests.swift
+++ b/NammaMeterTests/FareProfileTests.swift
@@ -74,32 +74,32 @@ final class FareProfileTests: XCTestCase {
   }
 
   func testSettingsStoreSeedsCatalogOnFirstLoad() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "fare-profiles.json")
     let store = SettingsStore(fileURL: url)
-    await waitForProfiles(store)
+    await TestHelpers.waitForProfiles(store)
 
     XCTAssertEqual(store.profiles.count, FareCatalog.entries.count)
     XCTAssertEqual(store.selectedCityId, FareCatalog.defaultCityId)
   }
 
   func testSettingsStoreAppendsCatalogUpdates() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "fare-profiles.json")
     let seed = FareProfileSettings(
       schemaVersion: FareProfileSettings.currentSchemaVersion,
       selectedCityId: FareCatalog.defaultCityId,
       profiles: [FareCatalog.defaultProfile],
       catalogVersionApplied: max(FareCatalog.currentVersion - 1, 0)
     )
-    try write(settings: seed, to: url)
+    try TestHelpers.write(settings: seed, to: url)
 
     let store = SettingsStore(fileURL: url)
-    await waitForProfiles(store)
+    await TestHelpers.waitForProfiles(store)
 
     XCTAssertEqual(store.profiles.count, FareCatalog.entries.count)
   }
 
   func testSettingsStoreFallbacksToBengaluru() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "fare-profiles.json")
     let fallbackProfile = try XCTUnwrap(FareCatalog.entries.first { $0.profile.cityId != FareCatalog.defaultCityId }?.profile)
     let seed = FareProfileSettings(
       schemaVersion: FareProfileSettings.currentSchemaVersion,
@@ -107,19 +107,19 @@ final class FareProfileTests: XCTestCase {
       profiles: [fallbackProfile],
       catalogVersionApplied: FareCatalog.currentVersion
     )
-    try write(settings: seed, to: url)
+    try TestHelpers.write(settings: seed, to: url)
 
     let store = SettingsStore(fileURL: url)
-    await waitForProfiles(store)
+    await TestHelpers.waitForProfiles(store)
 
     XCTAssertEqual(store.selectedCityId, FareCatalog.defaultCityId)
     XCTAssertTrue(store.profiles.contains { $0.cityId == FareCatalog.defaultCityId })
   }
 
   func testCitySelectionUpdatesMeterSettings() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "fare-profiles.json")
     let store = SettingsStore(fileURL: url)
-    await waitForProfiles(store)
+    await TestHelpers.waitForProfiles(store)
 
     let bengaluruBaseFare = store.settings.baseFare
     store.selectCity("mandya")
@@ -130,9 +130,9 @@ final class FareProfileTests: XCTestCase {
   }
 
   func testAvailableCitiesReturnsLatestProfiles() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "fare-profiles.json")
     let store = SettingsStore(fileURL: url)
-    await waitForProfiles(store)
+    await TestHelpers.waitForProfiles(store)
 
     let cities = store.availableCities
     XCTAssertEqual(cities.count, FareCatalog.entries.count)
@@ -142,9 +142,9 @@ final class FareProfileTests: XCTestCase {
   }
 
   func testAddCustomCity() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "fare-profiles.json")
     let store = SettingsStore(fileURL: url)
-    await waitForProfiles(store)
+    await TestHelpers.waitForProfiles(store)
 
     let initialCount = store.profiles.count
 
@@ -202,9 +202,9 @@ final class FareProfileTests: XCTestCase {
   }
 
   func testActiveCityInfo() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "fare-profiles.json")
     let store = SettingsStore(fileURL: url)
-    await waitForProfiles(store)
+    await TestHelpers.waitForProfiles(store)
 
     let cityInfo = store.activeCityInfo
     XCTAssertEqual(cityInfo.cityId, FareCatalog.defaultCityId)
@@ -216,26 +216,4 @@ final class FareProfileTests: XCTestCase {
     XCTAssertEqual(updatedInfo.cityName, "Mysuru")
   }
 
-  private func makeTempURL() throws -> URL {
-    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-    return dir.appendingPathComponent("fare-profiles.json")
-  }
-
-  private func write(settings: FareProfileSettings, to url: URL) throws {
-    let encoder = JSONEncoder()
-    encoder.dateEncodingStrategy = .iso8601
-    let data = try encoder.encode(settings)
-    try data.write(to: url, options: [.atomic])
-  }
-
-  private func waitForProfiles(_ store: SettingsStore) async {
-    for _ in 0..<60 {
-      if !store.profiles.isEmpty {
-        return
-      }
-      try? await Task.sleep(for: .milliseconds(50))
-    }
-    XCTFail("Timed out waiting for SettingsStore to load")
-  }
 }

--- a/NammaMeterTests/MeterStoreTests.swift
+++ b/NammaMeterTests/MeterStoreTests.swift
@@ -56,16 +56,10 @@ final class MeterStoreTests: XCTestCase {
   override func setUp() async throws {
     mockLocationProvider = MockLocationProvider()
     meterStore = MeterStore(locationProvider: mockLocationProvider)
-    let tempURL = FileManager.default.temporaryDirectory
-      .appendingPathComponent(UUID().uuidString)
-      .appendingPathComponent("trips.json")
-    try FileManager.default.createDirectory(
-      at: tempURL.deletingLastPathComponent(),
-      withIntermediateDirectories: true
-    )
+    let tempURL = try TestHelpers.makeTempURL(filename: "trips.json")
     tripStore = TripStore(fileURL: tempURL)
     // Wait for TripStore to initialize
-    try await Task.sleep(for: .milliseconds(100))
+    await TestHelpers.waitForTripStoreLoad(tripStore)
   }
 
   // MARK: - Trip Lifecycle Tests

--- a/NammaMeterTests/TestHelpers.swift
+++ b/NammaMeterTests/TestHelpers.swift
@@ -1,0 +1,60 @@
+import Foundation
+import XCTest
+@testable import NammaMeter
+
+struct TestHelpers {
+  static func makeTempURL(filename: String) throws -> URL {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir.appendingPathComponent(filename)
+  }
+
+  static func makeTrip(fare: Double, name: String? = nil) -> Trip {
+    Trip(
+      id: UUID(),
+      startDate: Date(timeIntervalSince1970: 1000000),
+      endDate: Date(timeIntervalSince1970: 1001800),
+      distanceMeters: 5000,
+      duration: 1800,
+      fare: fare,
+      points: [],
+      conditions: .clear,
+      rateSnapshot: RateSnapshot(settings: .bengaluruDefault),
+      multiplier: 1.0,
+      name: name
+    )
+  }
+
+  static func write(settings: FareProfileSettings, to url: URL) throws {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(settings)
+    try data.write(to: url, options: [.atomic])
+  }
+
+  @MainActor
+  static func waitForProfiles(
+    _ store: SettingsStore,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async {
+    for _ in 0..<60 {
+      if !store.profiles.isEmpty {
+        return
+      }
+      try? await Task.sleep(for: .milliseconds(50))
+    }
+    XCTFail("Timed out waiting for SettingsStore to load", file: file, line: line)
+  }
+
+  static func waitForTripStoreLoad(
+    _ store: TripStore,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) async {
+    for _ in 0..<60 {
+      try? await Task.sleep(for: .milliseconds(50))
+    }
+    try? await Task.sleep(for: .milliseconds(100))
+  }
+}

--- a/NammaMeterTests/TripStoreTests.swift
+++ b/NammaMeterTests/TripStoreTests.swift
@@ -8,12 +8,12 @@ final class TripStoreTests: XCTestCase {
   // MARK: - Add Tests
 
   func testAddTripInsertsAtFront() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
-    let trip1 = makeTrip(fare: 100)
-    let trip2 = makeTrip(fare: 200)
+    let trip1 = TestHelpers.makeTrip(fare: 100)
+    let trip2 = TestHelpers.makeTrip(fare: 200)
 
     store.add(trip1)
     store.add(trip2)
@@ -26,13 +26,13 @@ final class TripStoreTests: XCTestCase {
   // MARK: - Delete Tests
 
   func testDeleteAtOffsets() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
-    let trip1 = makeTrip(fare: 100)
-    let trip2 = makeTrip(fare: 200)
-    let trip3 = makeTrip(fare: 300)
+    let trip1 = TestHelpers.makeTrip(fare: 100)
+    let trip2 = TestHelpers.makeTrip(fare: 200)
+    let trip3 = TestHelpers.makeTrip(fare: 300)
 
     store.add(trip1)
     store.add(trip2)
@@ -47,11 +47,11 @@ final class TripStoreTests: XCTestCase {
   }
 
   func testDeleteAtMultipleOffsets() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
-    let trips = (0..<5).map { makeTrip(fare: Double($0 * 100)) }
+    let trips = (0..<5).map { TestHelpers.makeTrip(fare: Double($0 * 100)) }
     trips.forEach { store.add($0) }
 
     // Delete indices 1 and 3
@@ -61,13 +61,13 @@ final class TripStoreTests: XCTestCase {
   }
 
   func testDeleteByIds() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
-    let trip1 = makeTrip(fare: 100)
-    let trip2 = makeTrip(fare: 200)
-    let trip3 = makeTrip(fare: 300)
+    let trip1 = TestHelpers.makeTrip(fare: 100)
+    let trip2 = TestHelpers.makeTrip(fare: 200)
+    let trip3 = TestHelpers.makeTrip(fare: 300)
 
     store.add(trip1)
     store.add(trip2)
@@ -80,11 +80,11 @@ final class TripStoreTests: XCTestCase {
   }
 
   func testDeleteByEmptyIdsDoesNothing() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
-    let trip = makeTrip(fare: 100)
+    let trip = TestHelpers.makeTrip(fare: 100)
     store.add(trip)
 
     store.delete(ids: Set())
@@ -93,11 +93,11 @@ final class TripStoreTests: XCTestCase {
   }
 
   func testDeleteAll() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
-    let trips = (0..<5).map { makeTrip(fare: Double($0 * 100)) }
+    let trips = (0..<5).map { TestHelpers.makeTrip(fare: Double($0 * 100)) }
     trips.forEach { store.add($0) }
 
     store.deleteAll()
@@ -108,11 +108,11 @@ final class TripStoreTests: XCTestCase {
   // MARK: - Update Tests
 
   func testUpdateTrip() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
-    let trip = makeTrip(fare: 100)
+    let trip = TestHelpers.makeTrip(fare: 100)
     store.add(trip)
 
     store.update(trip.id) { $0.name = "Updated Name" }
@@ -121,11 +121,11 @@ final class TripStoreTests: XCTestCase {
   }
 
   func testUpdateNonExistentTripDoesNothing() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
-    let trip = makeTrip(fare: 100)
+    let trip = TestHelpers.makeTrip(fare: 100)
     store.add(trip)
 
     let nonExistentId = UUID()
@@ -137,12 +137,12 @@ final class TripStoreTests: XCTestCase {
   // MARK: - Lookup Tests
 
   func testTripForId() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
-    let trip1 = makeTrip(fare: 100)
-    let trip2 = makeTrip(fare: 200)
+    let trip1 = TestHelpers.makeTrip(fare: 100)
+    let trip2 = TestHelpers.makeTrip(fare: 200)
 
     store.add(trip1)
     store.add(trip2)
@@ -153,11 +153,11 @@ final class TripStoreTests: XCTestCase {
   }
 
   func testTripForIdReturnsNilForUnknown() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
-    let trip = makeTrip(fare: 100)
+    let trip = TestHelpers.makeTrip(fare: 100)
     store.add(trip)
 
     let found = store.trip(for: UUID())
@@ -167,14 +167,14 @@ final class TripStoreTests: XCTestCase {
   // MARK: - Persistence Tests
 
   func testTripsPersistedAndLoaded() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
 
     // Create store and add trips
     let store1 = TripStore(fileURL: url)
-    await waitForLoad(store1)
+    await TestHelpers.waitForTripStoreLoad(store1)
 
-    let trip1 = makeTrip(fare: 100, name: "Trip One")
-    let trip2 = makeTrip(fare: 200, name: "Trip Two")
+    let trip1 = TestHelpers.makeTrip(fare: 100, name: "Trip One")
+    let trip2 = TestHelpers.makeTrip(fare: 200, name: "Trip Two")
     store1.add(trip1)
     store1.add(trip2)
 
@@ -183,7 +183,7 @@ final class TripStoreTests: XCTestCase {
 
     // Create new store from same file
     let store2 = TripStore(fileURL: url)
-    await waitForLoad(store2)
+    await TestHelpers.waitForTripStoreLoad(store2)
 
     XCTAssertEqual(store2.trips.count, 2)
     XCTAssertEqual(store2.trips[0].name, "Trip Two")
@@ -191,74 +191,41 @@ final class TripStoreTests: XCTestCase {
   }
 
   func testEmptyFileReturnsEmptyArray() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
     // File doesn't exist - should load as empty
 
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
     XCTAssertTrue(store.trips.isEmpty)
   }
 
   func testCorruptedFileHandledGracefully() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
 
     // Write invalid JSON to file
     let corruptedData = "not valid json".data(using: .utf8)!
     try corruptedData.write(to: url)
 
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
     // Should gracefully handle and return empty
     XCTAssertTrue(store.trips.isEmpty)
   }
 
   func testPartiallyCorruptedJsonHandledGracefully() async throws {
-    let url = try makeTempURL()
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
 
     // Write JSON that's valid but wrong schema
     let wrongSchema = "[{\"wrong\": \"schema\"}]".data(using: .utf8)!
     try wrongSchema.write(to: url)
 
     let store = TripStore(fileURL: url)
-    await waitForLoad(store)
+    await TestHelpers.waitForTripStoreLoad(store)
 
     // Should gracefully handle and return empty
     XCTAssertTrue(store.trips.isEmpty)
   }
 
-  // MARK: - Helpers
-
-  private func makeTempURL() throws -> URL {
-    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-    return dir.appendingPathComponent("trips-test.json")
-  }
-
-  private func makeTrip(fare: Double, name: String? = nil) -> Trip {
-    Trip(
-      id: UUID(),
-      startDate: Date(timeIntervalSince1970: 1000000),
-      endDate: Date(timeIntervalSince1970: 1001800),
-      distanceMeters: 5000,
-      duration: 1800,
-      fare: fare,
-      points: [],
-      conditions: .clear,
-      rateSnapshot: RateSnapshot(settings: .bengaluruDefault),
-      multiplier: 1.0,
-      name: name
-    )
-  }
-
-  private func waitForLoad(_ store: TripStore) async {
-    // TripStore loads async in init, give it time to complete
-    for _ in 0..<60 {
-      try? await Task.sleep(for: .milliseconds(50))
-      // We can't directly check isLoaded, but after initial load trips is set
-      // Just wait a reasonable amount for async init
-    }
-    try? await Task.sleep(for: .milliseconds(100))
-  }
 }


### PR DESCRIPTION
## Summary
- introduce `TestHelpers` for shared temp URL creation, trip factories, and async wait helpers
- refactor `FareProfileTests`, `TripStoreTests`, and `MeterStoreTests` to use shared helpers
- keep test behavior the same while reducing duplicated setup code

## Testing
- `xcodebuild -scheme NammaMeter -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' test`

## Notes
- minor simulator/UI warnings during test run, but all tests passed

## Issue
- Closes #47
