### PR TITLE
Refactor: centralize trip state, metrics, and fare logic

### DIFF
--- a/NammaMeter/Calculation/FareCalculator.swift
+++ b/NammaMeter/Calculation/FareCalculator.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+struct FareCalculator {
+  let settings: MeterSettings
+
+  func calculateFare(
+    distanceKm: Double,
+    elapsedTime: TimeInterval,
+    waitingTime: TimeInterval,
+    isNight: Bool
+  ) -> Double {
+    let baseFare = settings.baseFare
+    let distanceFare = calculateDistanceFare(distanceKm)
+    let timeFare = calculateTimeFare(elapsedTime)
+    let waitFare = calculateWaitingFare(waitingTime)
+
+    let subtotal = baseFare + distanceFare + timeFare + waitFare
+    let multiplier = isNight ? settings.nightMultiplier : 1.0
+    let adjusted = subtotal * multiplier
+
+    return max(settings.minFare, adjusted)
+  }
+
+  func calculateDistanceFare(_ distanceKm: Double) -> Double {
+    guard distanceKm > settings.includedKm else { return 0 }
+    let extraKm = distanceKm - settings.includedKm
+    return extraKm * settings.perKmRate
+  }
+
+  func calculateTimeFare(_ elapsedTime: TimeInterval) -> Double {
+    let minutes = elapsedTime / 60
+    return minutes * settings.perMinuteRate
+  }
+
+  func calculateWaitingFare(_ waitingTime: TimeInterval) -> Double {
+    Self.calculateWaitingCharge(
+      waitingDuration: waitingTime,
+      freeWaitMinutes: settings.freeWaitMinutes,
+      waitIntervalMinutes: settings.waitIntervalMinutes,
+      waitIntervalCharge: settings.waitIntervalCharge
+    )
+  }
+
+  static func calculateWaitingCharge(
+    waitingDuration: TimeInterval,
+    freeWaitMinutes: Double,
+    waitIntervalMinutes: Double,
+    waitIntervalCharge: Double
+  ) -> Double {
+    let waitingMinutes = waitingDuration / 60
+    let chargeableMinutes = max(0, waitingMinutes - freeWaitMinutes)
+    guard waitIntervalMinutes > 0 else { return 0 }
+    let intervals = ceil(chargeableMinutes / waitIntervalMinutes)
+    return intervals * waitIntervalCharge
+  }
+
+  func validateSettings() -> [String] {
+    var errors: [String] = []
+
+    if settings.baseFare < 0 {
+      errors.append("Base fare cannot be negative")
+    }
+    if settings.perKmRate < 0 {
+      errors.append("Per-km rate cannot be negative")
+    }
+    if settings.includedKm < 0 {
+      errors.append("Included km cannot be negative")
+    }
+    if settings.minFare < 0 {
+      errors.append("Minimum fare cannot be negative")
+    }
+
+    return errors
+  }
+}

--- a/NammaMeter/MeterStore.swift
+++ b/NammaMeter/MeterStore.swift
@@ -31,15 +31,12 @@ extension CLLocationManager: LocationProviding {}
 @MainActor
 @Observable
 final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
-  var isOnTrip = false
-  var distanceMeters: Double = 0
-  var elapsed: TimeInterval = 0
+  private(set) var stateMachine = TripStateMachine()
+  private(set) var metrics = TripMetrics()
   var fare: Double = 0
   var points: [TripPoint] = []
   var currentSpeedKph: Double = 0
   var isWaiting = false
-  var waitingDuration: TimeInterval = 0
-  var tripState: TripMeterState = .forHire
   var authorizationStatus: CLAuthorizationStatus = .notDetermined
   var locationError: String?
   var conditions: TripConditions = .clear {
@@ -50,17 +47,23 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
     }
   }
 
+  var isOnTrip: Bool { stateMachine.isOnTrip }
+  var tripState: TripMeterState { stateMachine.tripState }
+  var distanceMeters: Double { metrics.distanceMeters }
+  var elapsed: TimeInterval { metrics.elapsedSeconds }
+  var waitingDuration: TimeInterval { metrics.waitingSeconds }
+
   @ObservationIgnored private let locationManager: LocationProviding
   @ObservationIgnored private var tickTask: Task<Void, Never>?
   @ObservationIgnored private var isUpdatingLocation = false
   @ObservationIgnored private let clock = ContinuousClock()
-  @ObservationIgnored private var startDate: Date?
   @ObservationIgnored private var lastLocation: CLLocation?
   @ObservationIgnored private var currentSettings: MeterSettings?
   @ObservationIgnored private var rateSnapshot: RateSnapshot?
   @ObservationIgnored private var multiplier: Double = 1
   @ObservationIgnored private var waitingStartedAt: Date?
   @ObservationIgnored private var waitingAccumulated: TimeInterval = 0
+  @ObservationIgnored private var fareCalculator: FareCalculator?
 
   override convenience init() {
     self.init(locationProvider: CLLocationManager())
@@ -89,25 +92,27 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
   }
 
   func startTrip(settings: MeterSettings, cityId: String? = nil, cityName: String? = nil) {
-    guard !isOnTrip else { return }
+    guard tripState == .forHire else { return }
     currentSettings = settings
     rateSnapshot = RateSnapshot(settings: settings, cityId: cityId, cityName: cityName)
-    refreshTimeBasedConditions(reference: Date())
-    multiplier = conditions.multiplier(using: settings)
-    isOnTrip = true
+    fareCalculator = FareCalculator(settings: settings)
+
+    metrics = TripMetrics()
     points = []
-    distanceMeters = 0
-    elapsed = 0
-    fare = settings.minFare
     currentSpeedKph = 0
     isWaiting = false
-    waitingDuration = 0
     waitingAccumulated = 0
     waitingStartedAt = nil
-    tripState = .inProgress
-    startDate = Date()
     lastLocation = nil
     locationError = nil
+
+    let startTime = Date()
+    stateMachine.startTrip(startTime: startTime)
+
+    refreshTimeBasedConditions(reference: startTime)
+    multiplier = conditions.multiplier(using: settings)
+    fare = settings.minFare
+    recalcFare()
 
     authorizationStatus = locationManager.authorizationStatus
     requestAuthorization()
@@ -120,36 +125,52 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
 
   func stopTrip(tripStore: TripStore) {
     guard isOnTrip else { return }
-    isOnTrip = false
     stopWaiting()
     stopLocationUpdates()
-    updateBackgroundLocationState()
     stopTicking()
 
     let endDate = Date()
     let snapshot = rateSnapshot ?? RateSnapshot(settings: currentSettings ?? .bengaluruDefault)
+    let startDate = stateMachine.startTime ?? endDate
     let trip = Trip(
       id: UUID(),
-      startDate: startDate ?? endDate,
+      startDate: startDate,
       endDate: endDate,
-      distanceMeters: distanceMeters,
-      duration: elapsed,
+      distanceMeters: metrics.distanceMeters,
+      duration: metrics.elapsedSeconds,
       fare: fare,
       points: points,
       conditions: conditions,
       rateSnapshot: snapshot,
       multiplier: multiplier,
-      waitingDuration: waitingDuration
+      waitingDuration: metrics.waitingSeconds
     )
+
+    stateMachine.completeTrip(trip: trip)
+    updateBackgroundLocationState()
+
     tripStore.add(trip)
     Task { await tripStore.resolveStartLocation(for: trip) }
+    fareCalculator = nil
     currentSettings = nil
-    tripState = .complete
   }
 
   func resetToForHire() {
     guard tripState == .complete else { return }
-    tripState = .forHire
+    stateMachine.resetToForHire()
+    metrics = metrics.reset()
+    points.removeAll()
+    fare = 0
+    currentSpeedKph = 0
+    isWaiting = false
+    waitingAccumulated = 0
+    waitingStartedAt = nil
+    lastLocation = nil
+    fareCalculator = nil
+    currentSettings = nil
+    rateSnapshot = nil
+    multiplier = 1
+    locationError = nil
   }
 
   private func startTicking() {
@@ -185,26 +206,21 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
     let now = Date()
     refreshTimeBasedConditions(reference: now)
     updateWaitingDuration(now)
-    if let startDate {
-      elapsed = now.timeIntervalSince(startDate)
+    if let startDate = stateMachine.startTime {
+      metrics.setElapsedTime(now.timeIntervalSince(startDate))
     }
     recalcFare()
   }
 
   private func recalcFare() {
     guard let settings = currentSettings else { return }
-    let distanceKm = distanceMeters / 1000
-    let includedKm = settings.includedKm
-    let chargeableDistanceKm = max(0, distanceKm - includedKm)
-    let waitingCharge = calculateWaitingCharge(
-      waitingDuration: waitingDuration,
-      freeWaitMinutes: settings.freeWaitMinutes,
-      waitIntervalMinutes: settings.waitIntervalMinutes,
-      waitIntervalCharge: settings.waitIntervalCharge
+    let calculator = fareCalculator ?? FareCalculator(settings: settings)
+    fare = calculator.calculateFare(
+      distanceKm: metrics.distanceKm,
+      elapsedTime: metrics.elapsedSeconds,
+      waitingTime: metrics.waitingSeconds,
+      isNight: conditions.isNight
     )
-    let rawFare = settings.baseFare + (chargeableDistanceKm * settings.perKmRate) + waitingCharge
-    let adjusted = rawFare * multiplier
-    fare = max(settings.minFare, adjusted)
   }
 
   func calculateWaitingCharge(
@@ -213,11 +229,12 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
     waitIntervalMinutes: Double,
     waitIntervalCharge: Double
   ) -> Double {
-    let waitingMinutes = waitingDuration / 60
-    let chargeableMinutes = max(0, waitingMinutes - freeWaitMinutes)
-    guard waitIntervalMinutes > 0 else { return 0 }
-    let intervals = ceil(chargeableMinutes / waitIntervalMinutes)
-    return intervals * waitIntervalCharge
+    FareCalculator.calculateWaitingCharge(
+      waitingDuration: waitingDuration,
+      freeWaitMinutes: freeWaitMinutes,
+      waitIntervalMinutes: waitIntervalMinutes,
+      waitIntervalCharge: waitIntervalCharge
+    )
   }
 
   func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
@@ -261,7 +278,7 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
         stopWaiting()
       }
       if delta > 2 {
-        distanceMeters += delta
+        metrics.addDistance(delta)
       }
     }
     lastLocation = location
@@ -286,14 +303,14 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
     }
     waitingStartedAt = nil
     isWaiting = false
-    waitingDuration = waitingAccumulated
+    metrics.setWaitingTime(waitingAccumulated)
   }
 
   private func updateWaitingDuration(_ now: Date) {
     if isWaiting, let waitingStartedAt {
-      waitingDuration = waitingAccumulated + now.timeIntervalSince(waitingStartedAt)
+      metrics.setWaitingTime(waitingAccumulated + now.timeIntervalSince(waitingStartedAt))
     } else {
-      waitingDuration = waitingAccumulated
+      metrics.setWaitingTime(waitingAccumulated)
     }
   }
 

--- a/NammaMeter/State/TripMetrics.swift
+++ b/NammaMeter/State/TripMetrics.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Observation
+
+@Observable
+final class TripMetrics {
+  private(set) var distanceMeters: Double = 0
+  private(set) var elapsedSeconds: TimeInterval = 0
+  private(set) var waitingSeconds: TimeInterval = 0
+
+  func addDistance(_ meters: Double) {
+    distanceMeters += meters
+  }
+
+  func addElapsedTime(_ seconds: TimeInterval) {
+    elapsedSeconds += seconds
+  }
+
+  func setElapsedTime(_ seconds: TimeInterval) {
+    elapsedSeconds = seconds
+  }
+
+  func addWaitingTime(_ seconds: TimeInterval) {
+    waitingSeconds += seconds
+  }
+
+  func setWaitingTime(_ seconds: TimeInterval) {
+    waitingSeconds = seconds
+  }
+
+  var distanceKm: Double {
+    distanceMeters / 1000
+  }
+
+  var formattedDistance: String {
+    String(format: "%.2f km", distanceKm)
+  }
+
+  var formattedElapsed: String {
+    let totalSeconds = max(Int(elapsedSeconds), 0)
+    let hours = totalSeconds / 3600
+    let minutes = (totalSeconds % 3600) / 60
+    let seconds = totalSeconds % 60
+    return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+  }
+
+  func reset() -> TripMetrics {
+    TripMetrics()
+  }
+}

--- a/NammaMeter/State/TripStateMachine.swift
+++ b/NammaMeter/State/TripStateMachine.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class TripStateMachine {
+  enum State {
+    case forHire
+    case inProgress(startTime: Date)
+    case complete(trip: Trip)
+  }
+
+  private(set) var currentState: State = .forHire
+  private(set) var stateHistory: [State] = []
+
+  func startTrip(startTime: Date = Date()) {
+    guard case .forHire = currentState else { return }
+    let newState = State.inProgress(startTime: startTime)
+    stateHistory.append(newState)
+    currentState = newState
+  }
+
+  func completeTrip(trip: Trip) {
+    guard case .inProgress = currentState else { return }
+    let newState = State.complete(trip: trip)
+    stateHistory.append(newState)
+    currentState = newState
+  }
+
+  func resetToForHire() {
+    guard case .complete = currentState else { return }
+    currentState = .forHire
+    stateHistory.append(.forHire)
+  }
+
+  var isOnTrip: Bool {
+    if case .inProgress = currentState { return true }
+    return false
+  }
+
+  var tripState: TripMeterState {
+    switch currentState {
+    case .forHire:
+      return .forHire
+    case .inProgress:
+      return .inProgress
+    case .complete:
+      return .complete
+    }
+  }
+
+  var startTime: Date? {
+    if case let .inProgress(startTime) = currentState {
+      return startTime
+    }
+    return nil
+  }
+
+  var completedTrip: Trip? {
+    if case let .complete(trip) = currentState {
+      return trip
+    }
+    return nil
+  }
+}

--- a/NammaMeterTests/FareCalculatorTests.swift
+++ b/NammaMeterTests/FareCalculatorTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import NammaMeter
+
+final class FareCalculatorTests: XCTestCase {
+  private var calculator: FareCalculator!
+  private var settings: MeterSettings!
+
+  override func setUp() {
+    super.setUp()
+    settings = MeterSettings.bengaluruDefault
+    calculator = FareCalculator(settings: settings)
+  }
+
+  func testBaseFareCharged() {
+    let fare = calculator.calculateFare(
+      distanceKm: 0,
+      elapsedTime: 0,
+      waitingTime: 0,
+      isNight: false
+    )
+
+    XCTAssertEqual(fare, settings.minFare)
+  }
+
+  func testDistanceFareCalculation() {
+    let distanceKm = settings.includedKm + 3.0
+    let fare = calculator.calculateFare(
+      distanceKm: distanceKm,
+      elapsedTime: 0,
+      waitingTime: 0,
+      isNight: false
+    )
+
+    let expectedExtra = (distanceKm - settings.includedKm) * settings.perKmRate
+    let expected = max(settings.minFare, settings.baseFare + expectedExtra)
+    XCTAssertEqual(fare, expected, accuracy: 0.01)
+  }
+
+  func testNightMultiplierApplied() {
+    let distanceKm = settings.includedKm + 3.0
+    let dayFare = calculator.calculateFare(
+      distanceKm: distanceKm,
+      elapsedTime: 300,
+      waitingTime: 0,
+      isNight: false
+    )
+
+    let nightFare = calculator.calculateFare(
+      distanceKm: distanceKm,
+      elapsedTime: 300,
+      waitingTime: 0,
+      isNight: true
+    )
+
+    let expected = max(settings.minFare, dayFare * settings.nightMultiplier)
+    XCTAssertEqual(nightFare, expected, accuracy: 0.01)
+  }
+
+  func testWaitingFareCalculation() {
+    let freeWaitMinutes = settings.freeWaitMinutes
+    let waitingTime = (freeWaitMinutes + 1) * 60
+
+    let fare = calculator.calculateFare(
+      distanceKm: 0,
+      elapsedTime: 0,
+      waitingTime: waitingTime,
+      isNight: false
+    )
+
+    let expectedWaitCharge = settings.waitIntervalCharge
+    let expected = max(settings.minFare, settings.baseFare + expectedWaitCharge)
+    XCTAssertEqual(fare, expected, accuracy: 0.01)
+  }
+}

--- a/NammaMeterTests/TripMetricsTests.swift
+++ b/NammaMeterTests/TripMetricsTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import NammaMeter
+
+final class TripMetricsTests: XCTestCase {
+  private var metrics: TripMetrics!
+
+  override func setUp() {
+    super.setUp()
+    metrics = TripMetrics()
+  }
+
+  func testMetricsAccumulation() {
+    metrics.addDistance(1000)
+    metrics.addElapsedTime(300)
+
+    XCTAssertEqual(metrics.distanceMeters, 1000)
+    XCTAssertEqual(metrics.elapsedSeconds, 300)
+  }
+
+  func testWaitingAccumulation() {
+    metrics.addWaitingTime(120)
+
+    XCTAssertEqual(metrics.waitingSeconds, 120)
+  }
+
+  func testFormattedOutput() {
+    metrics.addDistance(5000)
+    XCTAssertEqual(metrics.formattedDistance, "5.00 km")
+
+    metrics.setElapsedTime(3661)
+    XCTAssertEqual(metrics.formattedElapsed, "01:01:01")
+  }
+}

--- a/NammaMeterTests/TripStateMachineTests.swift
+++ b/NammaMeterTests/TripStateMachineTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import XCTest
+@testable import NammaMeter
+
+@MainActor
+final class TripStateMachineTests: XCTestCase {
+  private var stateMachine: TripStateMachine!
+
+  override func setUp() {
+    super.setUp()
+    stateMachine = TripStateMachine()
+  }
+
+  func testInitialState() {
+    XCTAssertEqual(stateMachine.tripState, .forHire)
+    XCTAssertFalse(stateMachine.isOnTrip)
+  }
+
+  func testStateTransitions() {
+    XCTAssertTrue(stateMachine.stateHistory.isEmpty)
+
+    stateMachine.startTrip()
+    XCTAssertTrue(stateMachine.isOnTrip)
+    XCTAssertEqual(stateMachine.tripState, .inProgress)
+
+    stateMachine.completeTrip(trip: makeTrip())
+    XCTAssertFalse(stateMachine.isOnTrip)
+    XCTAssertEqual(stateMachine.tripState, .complete)
+
+    stateMachine.resetToForHire()
+    XCTAssertFalse(stateMachine.isOnTrip)
+    XCTAssertEqual(stateMachine.tripState, .forHire)
+  }
+
+  func testInvalidTransitionsAreNoOps() {
+    stateMachine.startTrip()
+    stateMachine.startTrip()
+    XCTAssertEqual(stateMachine.stateHistory.count, 1)
+  }
+}
+
+private func makeTrip() -> Trip {
+  Trip(
+    id: UUID(),
+    startDate: Date(),
+    endDate: Date(),
+    distanceMeters: 0,
+    duration: 0,
+    fare: 0,
+    points: [],
+    conditions: .clear,
+    rateSnapshot: RateSnapshot(settings: .bengaluruDefault),
+    multiplier: 1,
+    waitingDuration: 0
+  )
+}


### PR DESCRIPTION
## Summary
- Extract trip lifecycle into `TripStateMachine` and metrics tracking into `TripMetrics`
- Move fare math into `FareCalculator` and keep `MeterStore` API stable by delegating
- Add unit tests for state machine, metrics, and fare calculator

## Testing
- `xcodebuild test -scheme NammaMeter -destination "platform=iOS Simulator,name=iPhone 17"`

Closes #42