### PR TITLE
Centralize location permission handling

### DIFF
--- a/NammaMeter/Location/LocationPermissionAlerts.swift
+++ b/NammaMeter/Location/LocationPermissionAlerts.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import UIKit
+
+struct LocationPermissionAlerts: ViewModifier {
+  @Bindable var coordinator: LocationPermissionCoordinator
+  @Environment(\.openURL) private var openURL
+
+  func body(content: Content) -> some View {
+    content
+      .alert("Location access needed", isPresented: $coordinator.showLocationDeniedAlert) {
+        Button("Open Settings") {
+          openSettings()
+        }
+        Button("Not Now", role: .cancel) {
+          coordinator.dismissDeniedAlert()
+        }
+      } message: {
+        Text("Enable location to track distance and replay routes.")
+      }
+      .alert("Enable background tracking", isPresented: $coordinator.showAlwaysPrompt) {
+        Button("Enable Always") {
+          coordinator.requestAlwaysAuthorization()
+          coordinator.dismissAlwaysPrompt()
+        }
+        Button("Open Settings") {
+          openSettings()
+        }
+        Button("Not Now", role: .cancel) {
+          coordinator.dismissAlwaysPrompt()
+        }
+      } message: {
+        Text("Allow Always location access to keep tracking distance when the app is in the background.")
+      }
+  }
+
+  private func openSettings() {
+    if let url = URL(string: UIApplication.openSettingsURLString) {
+      openURL(url)
+    }
+  }
+}
+
+extension View {
+  func withLocationPermissionHandling(coordinator: LocationPermissionCoordinator) -> some View {
+    modifier(LocationPermissionAlerts(coordinator: coordinator))
+  }
+}

--- a/NammaMeter/Location/LocationPermissionCoordinator.swift
+++ b/NammaMeter/Location/LocationPermissionCoordinator.swift
@@ -1,0 +1,70 @@
+import CoreLocation
+import Observation
+
+@MainActor
+@Observable
+final class LocationPermissionCoordinator {
+  private(set) var authorizationStatus: CLAuthorizationStatus
+  var showLocationDeniedAlert = false
+  var showAlwaysPrompt = false
+
+  @ObservationIgnored private let locationProvider: LocationProviding
+  @ObservationIgnored private var hasPromptedForAlways = false
+  @ObservationIgnored private var isOnTrip = false
+
+  init(locationProvider: LocationProviding) {
+    self.locationProvider = locationProvider
+    let status = locationProvider.authorizationStatus
+    authorizationStatus = status
+    showLocationDeniedAlert = status == .denied || status == .restricted
+  }
+
+  func refreshAuthorizationStatus() {
+    handleAuthorizationChange(locationProvider.authorizationStatus)
+  }
+
+  func requestWhenInUseIfNeeded() {
+    guard authorizationStatus == .notDetermined else { return }
+    locationProvider.requestWhenInUseAuthorization()
+  }
+
+  func requestAlwaysAuthorization() {
+    guard authorizationStatus == .authorizedWhenInUse else { return }
+    locationProvider.requestAlwaysAuthorization()
+  }
+
+  func handleAuthorizationChange(_ status: CLAuthorizationStatus) {
+    authorizationStatus = status
+    showLocationDeniedAlert = status == .denied || status == .restricted
+    if status == .authorizedAlways {
+      showAlwaysPrompt = false
+    }
+    evaluateAlwaysPromptIfNeeded()
+  }
+
+  func updateTripState(isOnTrip: Bool) {
+    self.isOnTrip = isOnTrip
+    if isOnTrip {
+      hasPromptedForAlways = false
+      evaluateAlwaysPromptIfNeeded()
+    } else {
+      showAlwaysPrompt = false
+    }
+  }
+
+  func dismissDeniedAlert() {
+    showLocationDeniedAlert = false
+  }
+
+  func dismissAlwaysPrompt() {
+    showAlwaysPrompt = false
+  }
+
+  private func evaluateAlwaysPromptIfNeeded() {
+    guard isOnTrip else { return }
+    guard authorizationStatus == .authorizedWhenInUse else { return }
+    guard !hasPromptedForAlways else { return }
+    hasPromptedForAlways = true
+    showAlwaysPrompt = true
+  }
+}

--- a/NammaMeter/MeterStore.swift
+++ b/NammaMeter/MeterStore.swift
@@ -37,7 +37,6 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
   var points: [TripPoint] = []
   var currentSpeedKph: Double = 0
   var isWaiting = false
-  var authorizationStatus: CLAuthorizationStatus = .notDetermined
   var locationError: String?
   var conditions: TripConditions = .clear {
     didSet {
@@ -54,6 +53,7 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
   var waitingDuration: TimeInterval { metrics.waitingSeconds }
 
   @ObservationIgnored private let locationManager: LocationProviding
+  @ObservationIgnored private let permissionCoordinator: LocationPermissionCoordinator
   @ObservationIgnored private var tickTask: Task<Void, Never>?
   @ObservationIgnored private var isUpdatingLocation = false
   @ObservationIgnored private let clock = ContinuousClock()
@@ -71,24 +71,22 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
 
   init(locationProvider: LocationProviding) {
     locationManager = locationProvider
+    permissionCoordinator = LocationPermissionCoordinator(locationProvider: locationProvider)
     super.init()
     locationManager.delegate = self
     locationManager.activityType = .automotiveNavigation
     locationManager.desiredAccuracy = kCLLocationAccuracyBest
     locationManager.distanceFilter = 8
     locationManager.pausesLocationUpdatesAutomatically = false
-    authorizationStatus = locationManager.authorizationStatus
   }
 
   func requestAuthorization() {
-    if authorizationStatus == .notDetermined {
-      locationManager.requestWhenInUseAuthorization()
-    }
+    permissionCoordinator.refreshAuthorizationStatus()
+    permissionCoordinator.requestWhenInUseIfNeeded()
   }
 
   func requestAlwaysAuthorization() {
-    guard authorizationStatus == .authorizedWhenInUse else { return }
-    locationManager.requestAlwaysAuthorization()
+    permissionCoordinator.requestAlwaysAuthorization()
   }
 
   func startTrip(settings: MeterSettings, cityId: String? = nil, cityName: String? = nil) {
@@ -108,13 +106,13 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
 
     let startTime = Date()
     stateMachine.startTrip(startTime: startTime)
+    permissionCoordinator.updateTripState(isOnTrip: true)
 
     refreshTimeBasedConditions(reference: startTime)
     multiplier = conditions.multiplier(using: settings)
     fare = settings.minFare
     recalcFare()
 
-    authorizationStatus = locationManager.authorizationStatus
     requestAuthorization()
     if isAuthorizedForLocationUpdates {
       startLocationUpdates()
@@ -147,6 +145,7 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
     )
 
     stateMachine.completeTrip(trip: trip)
+    permissionCoordinator.updateTripState(isOnTrip: false)
     updateBackgroundLocationState()
 
     tripStore.add(trip)
@@ -158,6 +157,7 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
   func resetToForHire() {
     guard tripState == .complete else { return }
     stateMachine.resetToForHire()
+    permissionCoordinator.updateTripState(isOnTrip: false)
     metrics = metrics.reset()
     points.removeAll()
     fare = 0
@@ -238,7 +238,7 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
   }
 
   func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-    authorizationStatus = manager.authorizationStatus
+    permissionCoordinator.handleAuthorizationChange(manager.authorizationStatus)
     if isOnTrip {
       if isAuthorizedForLocationUpdates {
         startLocationUpdates()
@@ -344,5 +344,13 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
     default:
       return false
     }
+  }
+
+  private var authorizationStatus: CLAuthorizationStatus {
+    permissionCoordinator.authorizationStatus
+  }
+
+  var locationPermissionCoordinator: LocationPermissionCoordinator {
+    permissionCoordinator
   }
 }

--- a/NammaMeter/MeterView.swift
+++ b/NammaMeter/MeterView.swift
@@ -1,21 +1,14 @@
-import CoreLocation
-import Foundation
 import SwiftUI
-import UIKit
 
 struct MeterView: View {
   @Environment(SettingsStore.self) private var settingsStore
   @Environment(TripStore.self) private var tripStore
   @Environment(MeterStore.self) private var meterStore
-  @Environment(\.openURL) private var openURL
-  @State private var showLocationAlert = false
-  @State private var showAlwaysPrompt = false
   @State private var showMeterSettings = false
   @State private var pagerSelection = 0
   @State private var meterFaceStyle: MeterFaceStyle = .superMeter
   @State private var meterRenderMode: MeterRenderMode = .full
   @State private var digitWheelStyle: DigitWheelStyle = .disk
-  @State private var hasPromptedForAlways = false
 
   var body: some View {
     NavigationStack {
@@ -29,49 +22,8 @@ struct MeterView: View {
       .onAppear {
         meterStore.requestAuthorization()
         meterStore.refreshTimeBasedConditions()
-        if meterStore.authorizationStatus == .denied || meterStore.authorizationStatus == .restricted {
-          showLocationAlert = true
-        }
       }
-      .onChange(of: meterStore.isOnTrip) { _, isOnTrip in
-        if isOnTrip {
-          hasPromptedForAlways = false
-          evaluateAlwaysPrompt()
-        } else {
-          showAlwaysPrompt = false
-        }
-      }
-      .onChange(of: meterStore.authorizationStatus) { _, newStatus in
-        if newStatus == .denied || newStatus == .restricted {
-          showLocationAlert = true
-        } else if newStatus == .authorizedAlways {
-          showAlwaysPrompt = false
-        }
-        evaluateAlwaysPrompt()
-      }
-      .alert("Location access needed", isPresented: $showLocationAlert) {
-        Button("Open Settings") {
-          if let url = URL(string: UIApplication.openSettingsURLString) {
-            openURL(url)
-          }
-        }
-        Button("Not Now", role: .cancel) { }
-      } message: {
-        Text("Enable location to track distance and replay routes.")
-      }
-      .alert("Enable background tracking", isPresented: $showAlwaysPrompt) {
-        Button("Enable Always") {
-          meterStore.requestAlwaysAuthorization()
-        }
-        Button("Open Settings") {
-          if let url = URL(string: UIApplication.openSettingsURLString) {
-            openURL(url)
-          }
-        }
-        Button("Not Now", role: .cancel) { }
-      } message: {
-        Text("Allow Always location access to keep tracking distance when the app is in the background.")
-      }
+      .withLocationPermissionHandling(coordinator: meterStore.locationPermissionCoordinator)
       .sheet(isPresented: $showMeterSettings) {
         meterSettingsSheet
       }
@@ -101,15 +53,6 @@ struct MeterView: View {
     )
   }
 
-  // MARK: - Helpers
-
-  private func evaluateAlwaysPrompt() {
-    guard meterStore.isOnTrip else { return }
-    guard meterStore.authorizationStatus == .authorizedWhenInUse else { return }
-    guard !hasPromptedForAlways else { return }
-    hasPromptedForAlways = true
-    showAlwaysPrompt = true
-  }
 }
 
 #Preview {

--- a/NammaMeterTests/LocationPermissionCoordinatorTests.swift
+++ b/NammaMeterTests/LocationPermissionCoordinatorTests.swift
@@ -1,0 +1,82 @@
+import CoreLocation
+import XCTest
+@testable import NammaMeter
+
+// MARK: - Stub Location Provider
+
+final class StubLocationProvider: LocationProviding {
+  var authorizationStatus: CLAuthorizationStatus
+  weak var delegate: CLLocationManagerDelegate?
+  var activityType: CLActivityType = .other
+  var desiredAccuracy: CLLocationAccuracy = kCLLocationAccuracyBest
+  var distanceFilter: CLLocationDistance = kCLDistanceFilterNone
+  var pausesLocationUpdatesAutomatically: Bool = false
+  var allowsBackgroundLocationUpdates: Bool = false
+  var showsBackgroundLocationIndicator: Bool = false
+
+  var didRequestWhenInUseAuthorization = false
+  var didRequestAlwaysAuthorization = false
+
+  init(status: CLAuthorizationStatus) {
+    authorizationStatus = status
+  }
+
+  func requestWhenInUseAuthorization() {
+    didRequestWhenInUseAuthorization = true
+  }
+
+  func requestAlwaysAuthorization() {
+    didRequestAlwaysAuthorization = true
+  }
+
+  func startUpdatingLocation() { }
+  func stopUpdatingLocation() { }
+}
+
+@MainActor
+final class LocationPermissionCoordinatorTests: XCTestCase {
+  func testInitialDeniedStatusShowsAlert() {
+    let provider = StubLocationProvider(status: .denied)
+    let coordinator = LocationPermissionCoordinator(locationProvider: provider)
+
+    XCTAssertEqual(coordinator.authorizationStatus, .denied)
+    XCTAssertTrue(coordinator.showLocationDeniedAlert)
+  }
+
+  func testRequestWhenInUseIfNeeded() {
+    let provider = StubLocationProvider(status: .notDetermined)
+    let coordinator = LocationPermissionCoordinator(locationProvider: provider)
+
+    coordinator.requestWhenInUseIfNeeded()
+
+    XCTAssertTrue(provider.didRequestWhenInUseAuthorization)
+  }
+
+  func testRequestAlwaysAuthorizationOnlyWhenWhenInUse() {
+    let provider = StubLocationProvider(status: .authorizedWhenInUse)
+    let coordinator = LocationPermissionCoordinator(locationProvider: provider)
+
+    coordinator.requestAlwaysAuthorization()
+
+    XCTAssertTrue(provider.didRequestAlwaysAuthorization)
+  }
+
+  func testHandleAuthorizationChangeSetsDeniedAlert() {
+    let provider = StubLocationProvider(status: .notDetermined)
+    let coordinator = LocationPermissionCoordinator(locationProvider: provider)
+
+    coordinator.handleAuthorizationChange(.denied)
+
+    XCTAssertEqual(coordinator.authorizationStatus, .denied)
+    XCTAssertTrue(coordinator.showLocationDeniedAlert)
+  }
+
+  func testTripStartPromptsAlwaysWhenAuthorizedWhenInUse() {
+    let provider = StubLocationProvider(status: .authorizedWhenInUse)
+    let coordinator = LocationPermissionCoordinator(locationProvider: provider)
+
+    coordinator.updateTripState(isOnTrip: true)
+
+    XCTAssertTrue(coordinator.showAlwaysPrompt)
+  }
+}


### PR DESCRIPTION
## Summary
- add a LocationPermissionCoordinator to own permission state and prompts
- move location permission alerts into a reusable view modifier
- wire MeterStore and MeterView to the coordinator
- add coordinator unit tests

## Testing
- xcodebuild test -scheme NammaMeter -destination "platform=iOS Simulator,name=iPhone 17 Pro"

Closes #46