### PR TITLE
Silence ResourceManifest default.csv log during tests

### DIFF
--- a/NammaMeter/MeterMapComponents.swift
+++ b/NammaMeter/MeterMapComponents.swift
@@ -10,17 +10,23 @@ struct LiveRouteMap: View {
   @State private var cameraPosition: MapCameraPosition = .automatic
 
   var body: some View {
-    Map(position: $cameraPosition) {
-      if points.count > 1 {
-        MapPolyline(coordinates: points.map { $0.coordinate })
-          .stroke(Theme.ink, lineWidth: 4)
-      }
-      if let start = points.first?.coordinate {
-        Marker("Start", coordinate: start)
-      }
-      if let end = points.last?.coordinate {
-        Annotation("Now", coordinate: end, anchor: .bottom) {
-          AutoLocationMarker()
+    Group {
+      if TestEnvironment.isRunningTests {
+        Color.clear
+      } else {
+        Map(position: $cameraPosition) {
+          if points.count > 1 {
+            MapPolyline(coordinates: points.map { $0.coordinate })
+              .stroke(Theme.ink, lineWidth: 4)
+          }
+          if let start = points.first?.coordinate {
+            Marker("Start", coordinate: start)
+          }
+          if let end = points.last?.coordinate {
+            Annotation("Now", coordinate: end, anchor: .bottom) {
+              AutoLocationMarker()
+            }
+          }
         }
       }
     }

--- a/NammaMeter/MeterStore.swift
+++ b/NammaMeter/MeterStore.swift
@@ -28,6 +28,22 @@ protocol LocationProviding: AnyObject {
 
 extension CLLocationManager: LocationProviding {}
 
+final class NoopLocationProvider: LocationProviding {
+  var authorizationStatus: CLAuthorizationStatus = .notDetermined
+  var delegate: CLLocationManagerDelegate?
+  var activityType: CLActivityType = .other
+  var desiredAccuracy: CLLocationAccuracy = kCLLocationAccuracyBest
+  var distanceFilter: CLLocationDistance = kCLLocationAccuracyBest
+  var pausesLocationUpdatesAutomatically: Bool = true
+  var allowsBackgroundLocationUpdates: Bool = false
+  var showsBackgroundLocationIndicator: Bool = false
+
+  func requestWhenInUseAuthorization() {}
+  func requestAlwaysAuthorization() {}
+  func startUpdatingLocation() {}
+  func stopUpdatingLocation() {}
+}
+
 @MainActor
 @Observable
 final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
@@ -66,7 +82,11 @@ final class MeterStore: NSObject, @preconcurrency CLLocationManagerDelegate {
   @ObservationIgnored private var fareCalculator: FareCalculator?
 
   override convenience init() {
-    self.init(locationProvider: CLLocationManager())
+    if TestEnvironment.isRunningTests {
+      self.init(locationProvider: NoopLocationProvider())
+    } else {
+      self.init(locationProvider: CLLocationManager())
+    }
   }
 
   init(locationProvider: LocationProviding) {

--- a/NammaMeter/MeterView.swift
+++ b/NammaMeter/MeterView.swift
@@ -20,7 +20,9 @@ struct MeterView: View {
           .padding(.bottom, 16)
       }
       .onAppear {
-        meterStore.requestAuthorization()
+        if !TestEnvironment.isRunningTests {
+          meterStore.requestAuthorization()
+        }
         meterStore.refreshTimeBasedConditions()
       }
       .withLocationPermissionHandling(coordinator: meterStore.locationPermissionCoordinator)

--- a/NammaMeter/TestEnvironment.swift
+++ b/NammaMeter/TestEnvironment.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum TestEnvironment {
+  static var isRunningTests: Bool {
+    ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+  }
+}


### PR DESCRIPTION
## Summary
- avoid MapKit + CoreLocation initialization during unit tests to eliminate the ResourceManifest default.csv log noise
- add a lightweight test environment check used by MeterStore, MeterView, and LiveRouteMap

## Testing
- xcodebuild test -project NammaMeter.xcodeproj -scheme NammaMeter -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -resultBundlePath .context/TestResults.xcresult

## Issue
- Closes #59
