### PR TITLE
Clamp meter layout sizing to avoid invalid frames

### DIFF
--- a/NammaMeter/MeterTypes.swift
+++ b/NammaMeter/MeterTypes.swift
@@ -300,9 +300,10 @@ struct MeterShell<Content: View>: View {
 
   var body: some View {
     GeometryReader { geo in
-      let desiredWidth = geo.size.width * style.widthRatio
+      let desiredWidth = max(geo.size.width * style.widthRatio, 0)
       let bodyHeightForWidth = desiredWidth * style.bodyAspect
-      let scale = min(1, geo.size.height / bodyHeightForWidth)
+      let rawScale = bodyHeightForWidth > 0 ? geo.size.height / bodyHeightForWidth : 0
+      let scale = rawScale.isFinite ? min(1, max(rawScale, 0)) : 0
       let bodyWidth = desiredWidth * scale
       let bodyHeight = bodyHeightForWidth * scale
       let cornerRadius = bodyWidth * style.cornerRadiusRatio

--- a/NammaMeter/SuperMechanicalMeterView.swift
+++ b/NammaMeter/SuperMechanicalMeterView.swift
@@ -19,14 +19,15 @@ struct SuperFullMeterPanel: View {
   var body: some View {
     GeometryReader { geo in
       // Calculate meter dimensions using shared constants
-      let desiredBodyWidth = geo.size.width * SuperMeterDimensions.widthRatio
+      let desiredBodyWidth = max(geo.size.width * SuperMeterDimensions.widthRatio, 0)
       let bodyHeightForWidth = desiredBodyWidth * SuperMeterDimensions.bodyAspect
       let canopyHeightForWidth = bodyHeightForWidth * SuperMeterDimensions.canopyRatio
       let baseHeightForWidth = bodyHeightForWidth * SuperMeterDimensions.baseRatio
       let totalHeightForWidth = bodyHeightForWidth + canopyHeightForWidth * SuperMeterDimensions.canopyOverlap + baseHeightForWidth
 
       // Scale to fit available height
-      let scale = min(1, geo.size.height / totalHeightForWidth)
+      let rawScale = totalHeightForWidth > 0 ? geo.size.height / totalHeightForWidth : 0
+      let scale = rawScale.isFinite ? min(1, max(rawScale, 0)) : 0
       let bodyWidth = desiredBodyWidth * scale
       let bodyHeight = bodyHeightForWidth * scale
       let canopyHeight = canopyHeightForWidth * scale

--- a/NammaMeter/Views/Meter/MeterLayoutContainer.swift
+++ b/NammaMeter/Views/Meter/MeterLayoutContainer.swift
@@ -16,14 +16,14 @@ struct MeterLayoutContainer: View {
       let controlBarHeight = min(max(geo.size.height * 0.085, 56), 72)
 
       // Available height after accounting for all fixed elements
-      let availableHeight = geo.size.height - bottomPadding - controlBarHeight - (spacing * 2)
+      let availableHeight = max(geo.size.height - bottomPadding - controlBarHeight - (spacing * 2), 0)
 
       // Use the largest meter height (Super Mechanical) to determine fixed map height
       // This ensures map size and position stay constant regardless of meter style
       let maxMeterNaturalHeight = SuperMeterDimensions.naturalHeight(for: geo.size.width)
-      let maxMeterHeight = availableHeight - minMapHeight
+      let maxMeterHeight = max(availableHeight - minMapHeight, 0)
       let referenceMeterHeight = min(maxMeterNaturalHeight, maxMeterHeight)
-      let fixedMapHeight = availableHeight - referenceMeterHeight
+      let fixedMapHeight = max(availableHeight - referenceMeterHeight, 0)
 
       VStack(spacing: spacing) {
         MeterPanelWithNotch(

--- a/NammaMeter/Views/Meter/MeterPagerView.swift
+++ b/NammaMeter/Views/Meter/MeterPagerView.swift
@@ -14,7 +14,7 @@ struct MeterPagerView: View {
     }
     .tabViewStyle(.page(indexDisplayMode: .always))
     .indexViewStyle(.page(backgroundDisplayMode: .always))
-    .frame(height: height)
+    .frame(height: max(height, 0))
     .background(PageSwipeDisabler().allowsHitTesting(false))
   }
 
@@ -29,8 +29,8 @@ struct MeterPagerView: View {
       GeometryReader { geo in
         let horizontalPadding: CGFloat = 12
         let columnSpacing: CGFloat = 12
-        let availableWidth = geo.size.width - (horizontalPadding * 2)
-        let columnWidth = (availableWidth - columnSpacing) / 2
+        let availableWidth = max(geo.size.width - (horizontalPadding * 2), 0)
+        let columnWidth = max((availableWidth - columnSpacing) / 2, 0)
         let tileHeight: CGFloat = 52
 
         let detailItems: [(String, String)] = [


### PR DESCRIPTION
## Summary
- Clamp geometry-derived sizes to prevent negative/NaN frames in meter shells.
- Guard layout heights/widths in the meter container and pager.

## Testing
```
xcodebuild test -project NammaMeter.xcodeproj -scheme NammaMeter -destination "platform=iOS Simulator,name=iPhone 17 Pro"
```

## Notes
- Observed warnings during tests (not new in this change):
  - AttributeGraph: cycle detected through attribute 52320.
  - User supplied UIDeviceFamily key in Info.plist will be overwritten; use TARGETED_DEVICE_FAMILY.
  - IOSurfaceClientSetSurfaceNotify failed e00002c7.
  - Multiple "Unbalanced calls to begin/end appearance transitions" for UIViewController during MeterStoreTests.

Closes #64
