### PR TITLE
Avoid zero-size Metal view rendering

### DIFF
--- a/NammaMeter/MeterMapComponents.swift
+++ b/NammaMeter/MeterMapComponents.swift
@@ -10,8 +10,8 @@ struct LiveRouteMap: View {
   @State private var cameraPosition: MapCameraPosition = .automatic
 
   var body: some View {
-    Group {
-      if TestEnvironment.isRunningTests {
+    GeometryReader { geo in
+      if TestEnvironment.isRunningTests || geo.size.width <= 0 || geo.size.height <= 0 {
         Color.clear
       } else {
         Map(position: $cameraPosition) {

--- a/NammaMeter/RickshawSceneView.swift
+++ b/NammaMeter/RickshawSceneView.swift
@@ -69,10 +69,16 @@ struct RickshawSceneView: View {
   }()
 
   var body: some View {
-    SceneView(
-      scene: scene,
-      options: [.autoenablesDefaultLighting]
-    )
+    GeometryReader { geo in
+      if TestEnvironment.isRunningTests || geo.size.width <= 0 || geo.size.height <= 0 {
+        Color.clear
+      } else {
+        SceneView(
+          scene: scene,
+          options: [.autoenablesDefaultLighting]
+        )
+      }
+    }
     .frame(height: 160)
     .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
     .shadow(color: Theme.pastelShadow(), radius: 12, x: 0, y: 6)

--- a/NammaMeter/TripDetailView.swift
+++ b/NammaMeter/TripDetailView.swift
@@ -128,20 +128,26 @@ struct TripDetailView: View {
         Spacer()
       }
 
-      Map(position: $cameraPosition) {
-        if coordinates.count > 1 {
-          MapPolyline(coordinates: coordinates)
-            .stroke(Theme.ink, lineWidth: 4)
-        }
-        if let start = coordinates.first {
-          Marker("Start", coordinate: start)
-        }
-        if let end = coordinates.last {
-          Marker("End", coordinate: end)
-        }
-        if let replayCoordinate = replayCoordinate(in: coordinates) {
-          Annotation("Replay", coordinate: replayCoordinate, anchor: .bottom) {
-            AutoLocationMarker()
+      GeometryReader { geo in
+        if TestEnvironment.isRunningTests || geo.size.width <= 0 || geo.size.height <= 0 {
+          Color.clear
+        } else {
+          Map(position: $cameraPosition) {
+            if coordinates.count > 1 {
+              MapPolyline(coordinates: coordinates)
+                .stroke(Theme.ink, lineWidth: 4)
+            }
+            if let start = coordinates.first {
+              Marker("Start", coordinate: start)
+            }
+            if let end = coordinates.last {
+              Marker("End", coordinate: end)
+            }
+            if let replayCoordinate = replayCoordinate(in: coordinates) {
+              Annotation("Replay", coordinate: replayCoordinate, anchor: .bottom) {
+                AutoLocationMarker()
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- guard Metal-backed Map/SceneView rendering when size is zero or tests are running
- apply guards to LiveRouteMap, TripDetail route map, and RickshawSceneView to prevent CAMetalLayer drawable warnings

## Testing
- xcodebuild test -project NammaMeter.xcodeproj -scheme NammaMeter -destination "platform=iOS Simulator,name=iPhone 17"

## Issues
- Closes #65