### PR TITLE
Remove UIDeviceFamily from Info.plist

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -43,11 +43,6 @@
   <true/>
   <key>UILaunchScreen</key>
   <dict/>
-  <key>UIDeviceFamily</key>
-  <array>
-    <integer>1</integer>
-    <integer>2</integer>
-  </array>
   <key>UISupportedInterfaceOrientations~ipad</key>
   <array>
     <string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
## Summary
- Remove UIDeviceFamily from Info.plist to clear the build warning.

## Testing
- `xcodebuild test -scheme NammaMeter -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`

## Warnings
- `IOSurfaceClientSetSurfaceNotify failed e00002c7` during `MeterSnapshotTests` (matches #71).

## Issues
- Closes #70.
