### PR TITLE
Remove previewDevice warning and stabilize fare tests

### DIFF
--- a/NammaMeter/SettingsView.swift
+++ b/NammaMeter/SettingsView.swift
@@ -93,5 +93,4 @@ struct LabeledValue: View {
   SettingsView()
     .environment(SettingsStore())
     .environment(MeterStore())
-    .previewDevice("iPhone 17 Pro")
 }

--- a/NammaMeterTests/MeterStoreTests.swift
+++ b/NammaMeterTests/MeterStoreTests.swift
@@ -79,6 +79,14 @@ final class MeterStoreTests: XCTestCase {
 
     meterStore.startTrip(settings: settings)
 
+    var dayComponents = DateComponents()
+    dayComponents.year = 2026
+    dayComponents.month = 2
+    dayComponents.day = 3
+    dayComponents.hour = 10
+    let dayDate = Calendar.autoupdatingCurrent.date(from: dayComponents)!
+    meterStore.refreshTimeBasedConditions(reference: dayDate)
+
     XCTAssertTrue(meterStore.isOnTrip)
     XCTAssertEqual(meterStore.tripState, .inProgress)
     XCTAssertEqual(meterStore.fare, settings.minFare)
@@ -114,6 +122,13 @@ final class MeterStoreTests: XCTestCase {
     let settings = MeterSettings.bengaluruDefault
 
     meterStore.startTrip(settings: settings)
+    var dayComponents = DateComponents()
+    dayComponents.year = 2026
+    dayComponents.month = 2
+    dayComponents.day = 3
+    dayComponents.hour = 10
+    let dayDate = Calendar.autoupdatingCurrent.date(from: dayComponents)!
+    meterStore.refreshTimeBasedConditions(reference: dayDate)
     XCTAssertTrue(tripStore.trips.isEmpty)
 
     meterStore.stopTrip(tripStore: tripStore)
@@ -241,6 +256,13 @@ final class MeterStoreTests: XCTestCase {
     settings.baseFare = 36
 
     meterStore.startTrip(settings: settings)
+    var dayComponents = DateComponents()
+    dayComponents.year = 2026
+    dayComponents.month = 2
+    dayComponents.day = 3
+    dayComponents.hour = 10
+    let dayDate = Calendar.autoupdatingCurrent.date(from: dayComponents)!
+    meterStore.refreshTimeBasedConditions(reference: dayDate)
 
     // Even with baseFare < minFare, fare should be minFare
     XCTAssertEqual(meterStore.fare, settings.minFare)


### PR DESCRIPTION
## Summary
- remove `.previewDevice(...)` from SettingsView `#Preview`
- force daytime conditions in MeterStore fare tests to avoid night multiplier flakes

## Testing
- `xcodebuild test -project NammaMeter.xcodeproj -scheme NammaMeter -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:NammaMeterTests/MeterStoreTests/testFareNeverBelowMinimum -only-testing:NammaMeterTests/MeterStoreTests/testStartTripInitializesState -only-testing:NammaMeterTests/MeterStoreTests/testStopTripCreatesTrip`

## Notes
- Warning still observed: `AttributeGraph: cycle detected` (tracked in #68)
- Warning still observed: `Metadata extraction skipped. No AppIntents.framework dependency found.` (tracked in #78)

Closes #76
