### PR TITLE
Enable Swift 6 strict concurrency checking

### DIFF
--- a/NammaMeter.xcodeproj/project.pbxproj
+++ b/NammaMeter.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
 			};
 			name = Debug;
 		};
@@ -304,6 +305,7 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/NammaMeterTests/ModelTests.swift
+++ b/NammaMeterTests/ModelTests.swift
@@ -123,7 +123,6 @@ final class ModelTests: XCTestCase {
     components.day = 3
 
     let expectedNightHours = Set([22, 23, 0, 1, 2, 3, 4])
-    let expectedDayHours = Set([5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
 
     for hour in 0..<24 {
       components.hour = hour

--- a/NammaMeterTests/TripStateMachineTests.swift
+++ b/NammaMeterTests/TripStateMachineTests.swift
@@ -6,8 +6,7 @@ import XCTest
 final class TripStateMachineTests: XCTestCase {
   private var stateMachine: TripStateMachine!
 
-  override func setUp() {
-    super.setUp()
+  override func setUp() async throws {
     stateMachine = TripStateMachine()
   }
 


### PR DESCRIPTION
## Summary

- Add `SWIFT_STRICT_CONCURRENCY=complete` to project-level Debug and Release configurations
- Fix concurrency warning in `TripStateMachineTests` by using async `setUp()` for proper main actor isolation
- Remove unused variable in `ModelTests`

## Audit Results

The app code had **zero concurrency warnings**, validating the existing architecture:
- `@MainActor` on stores
- Actor-based persistence
- `Sendable` conformance on models
- `@Observable` pattern usage

The only warnings were in test code where XCTest's nonisolated setUp pattern conflicted with `@MainActor` test classes.

## Test plan

- [x] Build succeeds with no concurrency errors
- [x] All 42 tests pass
- [x] No concurrency warnings in app code
- [x] Test code concurrency issues resolved

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)