### PR TITLE
Disable AppShortcuts metadata extraction for test target

### DIFF
--- a/NammaMeter.xcodeproj/project.pbxproj
+++ b/NammaMeter.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 		DA555CE8C78B491F80C89FF8 /* Debug configuration for PBXNativeTarget "NammaMeterTests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_SHORTCUTS_ENABLE_FLEXIBLE_MATCHING = NO;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -395,6 +396,7 @@
 		4B2793479E0740D49C7F6908 /* Release configuration for PBXNativeTarget "NammaMeterTests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_SHORTCUTS_ENABLE_FLEXIBLE_MATCHING = NO;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;


### PR DESCRIPTION
## Summary
- disable App Shortcuts flexible matching for `NammaMeterTests` in Debug and Release
- prevent `appintentsmetadataprocessor` from emitting missing AppIntents framework warnings for the test bundle

## Verification
- ran targeted tests on iPhone 17 simulator:
  - `xcodebuild test -project NammaMeter.xcodeproj -scheme NammaMeter -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:NammaMeterTests/MeterStoreTests/testFareNeverBelowMinimum -only-testing:NammaMeterTests/MeterStoreTests/testStartTripInitializesState -only-testing:NammaMeterTests/MeterStoreTests/testStopTripCreatesTrip`
- result: 3/3 tests passed
- warning removed for `NammaMeterTests`: `Metadata extraction skipped. No AppIntents.framework dependency found.`

Fixes [Issue #78](https://github.com/sridhar-sm/NammaMeter/issues/78)
