### PR TITLE
Add UI integration tests for critical user flows

### DIFF
--- a/NammaMeter.xcodeproj/project.pbxproj
+++ b/NammaMeter.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXFileReference section */
 		A5261D162EFC1AA700AABD5D /* NammaMeter.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NammaMeter.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A49A67CF1EFF40B89B436DA6 /* NammaMeterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NammaMeterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D1A0000100000000000000A1 /* NammaMeterUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NammaMeterUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -22,10 +23,22 @@
 			path = NammaMeterTests;
 			sourceTree = "<group>";
 		};
+		D1A0000200000000000000A2 /* NammaMeterUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = NammaMeterUITests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXContainerItemProxy section */
 		F4069BEB393B4F44AE0590EB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A5261D0E2EFC1AA700AABD5D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A5261D152EFC1AA700AABD5D /* NammaMeter */;
+			remoteInfo = NammaMeter;
+		};
+		D1A0000300000000000000A3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A5261D0E2EFC1AA700AABD5D /* Project object */;
 			proxyType = 1;
@@ -45,6 +58,11 @@
 			files = (
 			);
 		};
+		D1A0000600000000000000A6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			files = (
+			);
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -53,6 +71,7 @@
 			children = (
 				A5261D182EFC1AA700AABD5D /* NammaMeter */,
 				EB9085CEBB0940BCAAFBC434 /* NammaMeterTests */,
+				D1A0000200000000000000A2 /* NammaMeterUITests */,
 				A5261D172EFC1AA700AABD5D /* Products */,
 			);
 			indentWidth = 2;
@@ -64,6 +83,7 @@
 			children = (
 				A5261D162EFC1AA700AABD5D /* NammaMeter.app */,
 				A49A67CF1EFF40B89B436DA6 /* NammaMeterTests.xctest */,
+				D1A0000100000000000000A1 /* NammaMeterUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -113,6 +133,27 @@
 			productReference = A49A67CF1EFF40B89B436DA6 /* NammaMeterTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		D1A0000800000000000000A8 /* NammaMeterUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D1A0000B00000000000000AB /* Build configuration list for PBXNativeTarget "NammaMeterUITests" */;
+			buildPhases = (
+				D1A0000500000000000000A5 /* Sources */,
+				D1A0000600000000000000A6 /* Frameworks */,
+				D1A0000700000000000000A7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D1A0000400000000000000A4 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				D1A0000200000000000000A2 /* NammaMeterUITests */,
+			);
+			name = NammaMeterUITests;
+			productName = NammaMeterUITests;
+			productReference = D1A0000100000000000000A1 /* NammaMeterUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -128,6 +169,10 @@
 					};
 					4F81EC053778400FA0524DB5 = {
 						CreatedOnToolsVersion = 26.2;
+					};
+					D1A0000800000000000000A8 = {
+						CreatedOnToolsVersion = 26.2;
+						TestTargetID = A5261D152EFC1AA700AABD5D;
 					};
 				};
 			};
@@ -150,6 +195,7 @@
 			targets = (
 				A5261D152EFC1AA700AABD5D /* NammaMeter */,
 				4F81EC053778400FA0524DB5 /* NammaMeterTests */,
+				D1A0000800000000000000A8 /* NammaMeterUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -161,6 +207,11 @@
 			);
 		};
 		2E95E8ED2B634481BAB664C1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			files = (
+			);
+		};
+		D1A0000700000000000000A7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			files = (
 			);
@@ -178,6 +229,11 @@
 			files = (
 			);
 		};
+		D1A0000500000000000000A5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+			);
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -185,6 +241,11 @@
 			isa = PBXTargetDependency;
 			target = A5261D152EFC1AA700AABD5D /* NammaMeter */;
 			targetProxy = F4069BEB393B4F44AE0590EB /* PBXContainerItemProxy */;
+		};
+		D1A0000400000000000000A4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A5261D152EFC1AA700AABD5D /* NammaMeter */;
+			targetProxy = D1A0000300000000000000A3 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -416,6 +477,50 @@
 			};
 			name = Release;
 		};
+		D1A0000900000000000000A9 /* Debug configuration for PBXNativeTarget "NammaMeterUITests" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = D7JXMA95NW;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = sridharsm.NammaMeterUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_STRICT_CONCURRENCY = targeted;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = NammaMeter;
+			};
+			name = Debug;
+		};
+		D1A0000A00000000000000AA /* Release configuration for PBXNativeTarget "NammaMeterUITests" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = D7JXMA95NW;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = sridharsm.NammaMeterUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_STRICT_CONCURRENCY = targeted;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = NammaMeter;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -440,6 +545,14 @@
 			buildConfigurations = (
 				DA555CE8C78B491F80C89FF8 /* Debug configuration for PBXNativeTarget "NammaMeterTests" */,
 				4B2793479E0740D49C7F6908 /* Release configuration for PBXNativeTarget "NammaMeterTests" */,
+			);
+			defaultConfigurationName = Release;
+		};
+		D1A0000B00000000000000AB /* Build configuration list for PBXNativeTarget "NammaMeterUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D1A0000900000000000000A9 /* Debug configuration for PBXNativeTarget "NammaMeterUITests" */,
+				D1A0000A00000000000000AA /* Release configuration for PBXNativeTarget "NammaMeterUITests" */,
 			);
 			defaultConfigurationName = Release;
 		};

--- a/NammaMeter.xcodeproj/xcshareddata/xcschemes/NammaMeter.xcscheme
+++ b/NammaMeter.xcodeproj/xcshareddata/xcschemes/NammaMeter.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer="container:NammaMeter.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped="NO">
+            <BuildableReference
+               BuildableIdentifier="primary"
+               BlueprintIdentifier="D1A0000800000000000000A8"
+               BuildableName="NammaMeterUITests.xctest"
+               BlueprintName="NammaMeterUITests"
+               ReferencedContainer="container:NammaMeter.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/NammaMeter/NammaMeterApp.swift
+++ b/NammaMeter/NammaMeterApp.swift
@@ -2,7 +2,15 @@ import SwiftUI
 
 @main
 struct NammaMeterApp: App {
-  @State private var container = AppContainer()
+  @State private var container: AppContainer
+
+  init() {
+    if TestEnvironment.shouldResetState {
+      try? FileManager.default.removeItem(at: SettingsStore.defaultURL)
+      try? FileManager.default.removeItem(at: TripStore.defaultURL)
+    }
+    _container = State(initialValue: AppContainer())
+  }
 
   var body: some Scene {
     WindowGroup {

--- a/NammaMeter/TestEnvironment.swift
+++ b/NammaMeter/TestEnvironment.swift
@@ -4,4 +4,8 @@ enum TestEnvironment {
   static var isRunningTests: Bool {
     ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
   }
+
+  static var shouldResetState: Bool {
+    ProcessInfo.processInfo.arguments.contains("--reset-state")
+  }
 }

--- a/NammaMeter/Views/History/HistoryActionBar.swift
+++ b/NammaMeter/Views/History/HistoryActionBar.swift
@@ -18,6 +18,7 @@ struct HistoryActionBar: View {
           mangoPillLabel(isAllSelected ? "Deselect All" : "Select All")
         }
         .accessibilityLabel(isAllSelected ? "Deselect All" : "Select All")
+        .accessibilityIdentifier("history.selectAllButton")
       }
       Spacer()
       if showDelete {
@@ -29,6 +30,7 @@ struct HistoryActionBar: View {
         .tint(.red)
         .buttonStyle(.bordered)
         .controlSize(.small)
+        .accessibilityIdentifier("history.deleteButton")
       }
       Button {
         onToggleEdit()
@@ -36,6 +38,7 @@ struct HistoryActionBar: View {
         mangoPillLabel(isEditing ? "Done" : "Edit")
       }
       .accessibilityLabel(isEditing ? "Done" : "Edit")
+      .accessibilityIdentifier("history.editButton")
     }
   }
 

--- a/NammaMeter/Views/Meter/MeterControlBar.swift
+++ b/NammaMeter/Views/Meter/MeterControlBar.swift
@@ -49,6 +49,7 @@ struct MeterControlBar: View {
     }
     .buttonStyle(.plain)
     .accessibilityLabel("Meter settings")
+    .accessibilityIdentifier("meter.settingsButton")
   }
 
   private func nightConditionButton(metrics: ControlBarMetrics) -> some View {
@@ -77,6 +78,7 @@ struct MeterControlBar: View {
     }
     .buttonStyle(.plain)
     .accessibilityLabel(tripToggleAccessibilityLabel)
+    .accessibilityIdentifier("meter.tripToggle")
   }
 
   private func waitToggleButton(metrics: ControlBarMetrics) -> some View {
@@ -94,6 +96,7 @@ struct MeterControlBar: View {
     .disabled(!meterStore.isOnTrip)
     .opacity(meterStore.isOnTrip ? 1 : 0.6)
     .accessibilityLabel(meterStore.isWaiting ? "Resume trip" : "Pause trip")
+    .accessibilityIdentifier("meter.waitToggle")
   }
 
   private var tripToggleAccessibilityLabel: String {

--- a/NammaMeter/Views/Settings/SettingsResetSection.swift
+++ b/NammaMeter/Views/Settings/SettingsResetSection.swift
@@ -10,6 +10,7 @@ struct SettingsResetSection: View {
       } label: {
         Text("Reset to defaults")
       }
+      .accessibilityIdentifier("settings.resetButton")
     }
   }
 }

--- a/NammaMeterUITests/HistoryUITests.swift
+++ b/NammaMeterUITests/HistoryUITests.swift
@@ -1,0 +1,80 @@
+@preconcurrency import XCTest
+
+final class HistoryUITests: NammaMeterUITestCase {
+
+  /// Creates a trip by running start/stop/reset from the Meter tab.
+  private func createTrip() {
+    tapTab("Meter")
+    let tripToggle = app.buttons["meter.tripToggle"]
+    XCTAssertTrue(tripToggle.waitForExistence(timeout: 3))
+
+    tripToggle.tap()
+    waitForLabel(tripToggle, toBe: "Stop trip")
+
+    tripToggle.tap()
+    waitForLabel(tripToggle, toBe: "Reset trip")
+
+    tripToggle.tap()
+    waitForLabel(tripToggle, toBe: "Start trip")
+  }
+
+  func testEmptyState() {
+    tapTab("Trips")
+    let emptyState = app.staticTexts["No trips yet"]
+    XCTAssertTrue(emptyState.waitForExistence(timeout: 5))
+  }
+
+  func testTripAppearsAfterCreation() {
+    createTrip()
+    tapTab("Trips")
+
+    let emptyState = app.staticTexts["No trips yet"]
+    XCTAssertFalse(emptyState.waitForExistence(timeout: 2))
+
+    let cells = app.cells
+    XCTAssertGreaterThan(cells.count, 0, "At least one trip row should be visible")
+  }
+
+  func testSwipeToDelete() {
+    createTrip()
+    tapTab("Trips")
+
+    let firstCell = app.cells.element(boundBy: 0)
+    XCTAssertTrue(firstCell.waitForExistence(timeout: 5))
+
+    firstCell.swipeLeft()
+
+    let deleteButton = app.buttons["Delete"]
+    if deleteButton.waitForExistence(timeout: 2) {
+      deleteButton.tap()
+    }
+
+    let emptyState = app.staticTexts["No trips yet"]
+    XCTAssertTrue(emptyState.waitForExistence(timeout: 5))
+  }
+
+  func testBulkDelete() {
+    createTrip()
+    createTrip()
+    tapTab("Trips")
+
+    // Enter edit mode
+    let editButton = app.buttons["history.editButton"]
+    XCTAssertTrue(editButton.waitForExistence(timeout: 5))
+    editButton.tap()
+
+    // Select All
+    let selectAll = app.buttons["history.selectAllButton"]
+    XCTAssertTrue(selectAll.waitForExistence(timeout: 3))
+    selectAll.tap()
+
+    // Delete
+    let deleteButton = app.buttons["history.deleteButton"]
+    XCTAssertTrue(deleteButton.waitForExistence(timeout: 3))
+    deleteButton.tap()
+
+    // Verify empty
+    let emptyState = app.staticTexts["No trips yet"]
+    XCTAssertTrue(emptyState.waitForExistence(timeout: 5))
+  }
+}

--- a/NammaMeterUITests/MeterUITests.swift
+++ b/NammaMeterUITests/MeterUITests.swift
@@ -1,0 +1,53 @@
+@preconcurrency import XCTest
+
+final class MeterUITests: NammaMeterUITestCase {
+
+  func testTripLifecycle() {
+    let tripToggle = app.buttons["meter.tripToggle"]
+    XCTAssertTrue(waitFor(tripToggle))
+    XCTAssertEqual(tripToggle.label, "Start trip")
+
+    // Start trip
+    tripToggle.tap()
+    waitForLabel(tripToggle, toBe: "Stop trip")
+
+    // Stop trip
+    tripToggle.tap()
+    waitForLabel(tripToggle, toBe: "Reset trip")
+
+    // Verify trip saved in History
+    tapTab("Trips")
+    let emptyState = app.staticTexts["No trips yet"]
+    XCTAssertFalse(emptyState.waitForExistence(timeout: 2), "Trip should have been saved to history")
+
+    // Go back and reset
+    tapTab("Meter")
+    tripToggle.tap()
+    waitForLabel(tripToggle, toBe: "Start trip")
+  }
+
+  func testWaitingToggle() {
+    let tripToggle = app.buttons["meter.tripToggle"]
+    XCTAssertTrue(waitFor(tripToggle))
+
+    // Start trip
+    tripToggle.tap()
+    waitForLabel(tripToggle, toBe: "Stop trip")
+
+    // Toggle waiting on
+    let waitToggle = app.buttons["meter.waitToggle"]
+    let enabledPredicate = NSPredicate(format: "isEnabled == true")
+    let enabledExpectation = XCTNSPredicateExpectation(predicate: enabledPredicate, object: waitToggle)
+    let enabledResult = XCTWaiter.wait(for: [enabledExpectation], timeout: 5)
+    XCTAssertEqual(enabledResult, .completed, "Wait toggle should become enabled")
+    waitToggle.tap()
+    waitForLabel(waitToggle, toBe: "Resume trip")
+
+    // Toggle waiting off
+    waitToggle.tap()
+    waitForLabel(waitToggle, toBe: "Pause trip")
+
+    // Clean up
+    tripToggle.tap()
+  }
+}

--- a/NammaMeterUITests/NammaMeterUITestCase.swift
+++ b/NammaMeterUITests/NammaMeterUITestCase.swift
@@ -1,0 +1,34 @@
+@preconcurrency import XCTest
+
+class NammaMeterUITestCase: XCTestCase {
+  var app: XCUIApplication!
+
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+    app = XCUIApplication()
+    app.launchArguments = ["--uitesting", "--reset-state"]
+    app.launch()
+  }
+
+  override func tearDownWithError() throws {
+    app = nil
+  }
+
+  // MARK: - Helpers
+
+  func tapTab(_ name: String) {
+    app.tabBars.buttons[name].tap()
+  }
+
+  @discardableResult
+  func waitFor(_ element: XCUIElement, timeout: TimeInterval = 5) -> Bool {
+    element.waitForExistence(timeout: timeout)
+  }
+
+  func waitForLabel(_ element: XCUIElement, toBe label: String, timeout: TimeInterval = 5) {
+    let predicate = NSPredicate(format: "label == %@", label)
+    let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+    let result = XCTWaiter.wait(for: [expectation], timeout: timeout)
+    XCTAssertEqual(result, .completed, "Expected label '\(label)' but got '\(element.label)'")
+  }
+}

--- a/NammaMeterUITests/NavigationUITests.swift
+++ b/NammaMeterUITests/NavigationUITests.swift
@@ -1,0 +1,59 @@
+@preconcurrency import XCTest
+
+final class NavigationUITests: NammaMeterUITestCase {
+
+  func testTabSwitching() {
+    let meterTab = app.tabBars.buttons["Meter"]
+    let tripsTab = app.tabBars.buttons["Trips"]
+    let settingsTab = app.tabBars.buttons["Settings"]
+
+    XCTAssertTrue(waitFor(meterTab))
+
+    // Switch to Trips
+    tripsTab.tap()
+    XCTAssertTrue(app.staticTexts["Trips"].waitForExistence(timeout: 3))
+
+    // Switch to Settings
+    settingsTab.tap()
+    XCTAssertTrue(app.staticTexts["Settings"].waitForExistence(timeout: 3))
+
+    // Switch back to Meter
+    meterTab.tap()
+    XCTAssertTrue(app.buttons["meter.tripToggle"].waitForExistence(timeout: 3))
+  }
+
+  func testMeterSettingsSheet() {
+    let settingsButton = app.buttons["meter.settingsButton"]
+    XCTAssertTrue(waitFor(settingsButton))
+
+    settingsButton.tap()
+
+    // Verify sheet content
+    let doneButton = app.buttons["Done"]
+    XCTAssertTrue(doneButton.waitForExistence(timeout: 3))
+    XCTAssertTrue(app.staticTexts["Meter Style"].exists)
+    XCTAssertTrue(app.buttons["Super Mechanical"].exists)
+    XCTAssertTrue(app.buttons["Super Electronic"].exists)
+
+    // Dismiss
+    doneButton.tap()
+    XCTAssertTrue(settingsButton.waitForExistence(timeout: 3))
+  }
+
+  func testManageCitiesNavigation() {
+    tapTab("Settings")
+
+    let manageCities = app.staticTexts["Manage Cities"]
+    XCTAssertTrue(manageCities.waitForExistence(timeout: 5))
+    manageCities.tap()
+
+    // Verify navigation pushed
+    XCTAssertTrue(app.navigationBars["Manage Cities"].waitForExistence(timeout: 3))
+
+    // Navigate back
+    app.navigationBars.buttons.element(boundBy: 0).tap()
+
+    // Verify we're back on Settings
+    XCTAssertTrue(manageCities.waitForExistence(timeout: 3))
+  }
+}

--- a/NammaMeterUITests/SettingsUITests.swift
+++ b/NammaMeterUITests/SettingsUITests.swift
@@ -1,0 +1,34 @@
+@preconcurrency import XCTest
+
+final class SettingsUITests: NammaMeterUITestCase {
+
+  func testDefaultCityDisplayed() {
+    tapTab("Settings")
+    let bengaluru = app.staticTexts["Bengaluru"]
+    XCTAssertTrue(bengaluru.waitForExistence(timeout: 5), "Default city Bengaluru should be visible")
+  }
+
+  func testRatesDisplayed() {
+    tapTab("Settings")
+
+    let baseFare = app.staticTexts["Base Fare"]
+    XCTAssertTrue(baseFare.waitForExistence(timeout: 5), "Base Fare label should be visible")
+
+    let perKm = app.staticTexts["Per Km"]
+    XCTAssertTrue(perKm.waitForExistence(timeout: 3), "Per Km label should be visible")
+
+    let minimumFare = app.staticTexts["Minimum Fare"]
+    XCTAssertTrue(minimumFare.waitForExistence(timeout: 3), "Minimum Fare label should be visible")
+  }
+
+  func testManageCitiesShowsCatalogCities() {
+    tapTab("Settings")
+
+    let manageCities = app.staticTexts["Manage Cities"]
+    XCTAssertTrue(manageCities.waitForExistence(timeout: 5))
+    manageCities.tap()
+
+    let bengaluru = app.staticTexts["Bengaluru"]
+    XCTAssertTrue(bengaluru.waitForExistence(timeout: 5), "Bengaluru should be listed in Manage Cities")
+  }
+}


### PR DESCRIPTION
## Summary
- Add XCUITest target with **12 UI tests** across 4 test suites covering meter controls, trip history, tab navigation, and settings
- Add accessibility identifiers to `MeterControlBar` (3), `HistoryActionBar` (3), and `SettingsResetSection` (1) for stable test element queries
- Add `--reset-state` launch argument support to clear persisted data for deterministic UI test runs
- Set `SWIFT_STRICT_CONCURRENCY = targeted` on UI test target (XCUITest APIs are not yet compatible with `complete` concurrency checking)

### Test coverage
| Suite | Tests | Flows covered |
|-------|-------|---------------|
| `MeterUITests` | 2 | Trip lifecycle (start → stop → reset), waiting toggle |
| `HistoryUITests` | 4 | Empty state, trip creation, swipe-to-delete, bulk delete |
| `NavigationUITests` | 3 | Tab switching, meter settings sheet, manage cities navigation |
| `SettingsUITests` | 3 | Default city display, rates display, manage cities catalog |

Closes #81

## Test plan
- [x] All 12 UI tests pass on iPhone 17 Pro simulator (zero failures)
- [x] All 158 unit tests continue to pass (zero regressions)
- [x] Clean build with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)