### PR TITLE
Extract reverse geocoding into GeocodingService

### DIFF
--- a/NammaMeter/Location/GeocodingService.swift
+++ b/NammaMeter/Location/GeocodingService.swift
@@ -1,0 +1,84 @@
+import CoreLocation
+import Foundation
+
+protocol GeocodingServiceProtocol: Sendable {
+  func cityName(for coordinate: CLLocationCoordinate2D) async -> String?
+}
+
+struct GeocodingPlacemark: Sendable {
+  let locality: String?
+  let subAdministrativeArea: String?
+  let administrativeArea: String?
+}
+
+actor GeocodingService: GeocodingServiceProtocol {
+  typealias ReverseGeocode = @Sendable (CLLocationCoordinate2D) async throws -> GeocodingPlacemark?
+
+  private var cache: [CacheKey: String] = [:]
+  private var cacheOrder: [CacheKey] = []
+  private let maxCacheEntries: Int
+  private let reverseGeocode: ReverseGeocode
+
+  init(
+    maxCacheEntries: Int = 48,
+    reverseGeocode: @escaping ReverseGeocode = GeocodingService.liveReverseGeocode
+  ) {
+    self.maxCacheEntries = max(1, maxCacheEntries)
+    self.reverseGeocode = reverseGeocode
+  }
+
+  func cityName(for coordinate: CLLocationCoordinate2D) async -> String? {
+    if Task.isCancelled { return nil }
+    let key = CacheKey(coordinate: coordinate)
+    if let cached = cache[key] {
+      return cached
+    }
+
+    do {
+      guard let placemark = try await reverseGeocode(coordinate) else { return nil }
+      let city = placemark.locality
+        ?? placemark.subAdministrativeArea
+        ?? placemark.administrativeArea
+      guard let city, !city.isEmpty else { return nil }
+      insertCache(city, for: key)
+      return city
+    } catch {
+      return nil
+    }
+  }
+
+  private func insertCache(_ city: String, for key: CacheKey) {
+    cache[key] = city
+    cacheOrder.removeAll { $0 == key }
+    cacheOrder.append(key)
+
+    if cacheOrder.count > maxCacheEntries, let oldest = cacheOrder.first {
+      cacheOrder.removeFirst()
+      cache.removeValue(forKey: oldest)
+    }
+  }
+
+  nonisolated private static func liveReverseGeocode(
+    coordinate: CLLocationCoordinate2D
+  ) async throws -> GeocodingPlacemark? {
+    let location = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+    let placemarks = try await CLGeocoder().reverseGeocodeLocation(location)
+    guard let placemark = placemarks.first else { return nil }
+    return GeocodingPlacemark(
+      locality: placemark.locality,
+      subAdministrativeArea: placemark.subAdministrativeArea,
+      administrativeArea: placemark.administrativeArea
+    )
+  }
+
+  private struct CacheKey: Hashable {
+    let lat: Int
+    let lon: Int
+
+    init(coordinate: CLLocationCoordinate2D) {
+      let scale = 100.0
+      lat = Int((coordinate.latitude * scale).rounded())
+      lon = Int((coordinate.longitude * scale).rounded())
+    }
+  }
+}

--- a/NammaMeter/TripStore.swift
+++ b/NammaMeter/TripStore.swift
@@ -17,10 +17,14 @@ final class TripStore {
   @ObservationIgnored private let persistence: TripPersistence
   @ObservationIgnored private var isLoaded = false
   @ObservationIgnored private var saveTask: Task<Void, Never>?
-  @ObservationIgnored private let geocoder = GeocodingService()
+  @ObservationIgnored private let geocoder: any GeocodingServiceProtocol
 
-  init(fileURL: URL = TripStore.defaultURL) {
+  init(
+    fileURL: URL = TripStore.defaultURL,
+    geocoder: any GeocodingServiceProtocol = GeocodingService()
+  ) {
     self.persistence = TripPersistence(url: fileURL)
+    self.geocoder = geocoder
     Task { await load() }
   }
 
@@ -58,8 +62,7 @@ final class TripStore {
     guard trip.startLocationName == nil else { return }
     guard let start = trip.points.first else { return }
     if Task.isCancelled { return }
-    let location = CLLocation(latitude: start.latitude, longitude: start.longitude)
-    guard let city = await geocoder.cityName(for: location) else { return }
+    guard let city = await geocoder.cityName(for: start.coordinate) else { return }
     if Task.isCancelled { return }
     update(trip.id) { $0.startLocationName = city }
   }
@@ -105,53 +108,5 @@ private actor TripPersistence {
     encoder.dateEncodingStrategy = .iso8601
     guard let data = try? encoder.encode(trips) else { return }
     try? data.write(to: url, options: [.atomic])
-  }
-}
-
-private actor GeocodingService {
-  private var cache: [CacheKey: String] = [:]
-  private var cacheOrder: [CacheKey] = []
-  private let maxCacheEntries = 48
-
-  func cityName(for location: CLLocation) async -> String? {
-    if Task.isCancelled { return nil }
-    let key = CacheKey(location: location)
-    if let cached = cache[key] {
-      return cached
-    }
-    let geocoder = CLGeocoder()
-    do {
-      let placemarks = try await geocoder.reverseGeocodeLocation(location)
-      guard let placemark = placemarks.first else { return nil }
-      let city = placemark.locality
-        ?? placemark.subAdministrativeArea
-        ?? placemark.administrativeArea
-      guard let city, !city.isEmpty else { return nil }
-      insertCache(city, for: key)
-      return city
-    } catch {
-      return nil
-    }
-  }
-
-  private func insertCache(_ city: String, for key: CacheKey) {
-    cache[key] = city
-    cacheOrder.removeAll { $0 == key }
-    cacheOrder.append(key)
-    if cacheOrder.count > maxCacheEntries, let oldest = cacheOrder.first {
-      cacheOrder.removeFirst()
-      cache.removeValue(forKey: oldest)
-    }
-  }
-
-  private struct CacheKey: Hashable {
-    let lat: Int
-    let lon: Int
-
-    init(location: CLLocation) {
-      let scale = 100.0
-      lat = Int((location.coordinate.latitude * scale).rounded())
-      lon = Int((location.coordinate.longitude * scale).rounded())
-    }
   }
 }

--- a/NammaMeterTests/GeocodingServiceTests.swift
+++ b/NammaMeterTests/GeocodingServiceTests.swift
@@ -1,0 +1,145 @@
+import CoreLocation
+import XCTest
+@testable import NammaMeter
+
+final class GeocodingServiceTests: XCTestCase {
+
+  func testCityNamePrefersLocality() async {
+    let resolver = ReverseGeocodeStub(
+      outcomes: [
+        .placemark(
+          GeocodingPlacemark(
+            locality: "Bengaluru",
+            subAdministrativeArea: "Bangalore Urban",
+            administrativeArea: "Karnataka"
+          )
+        )
+      ]
+    )
+    let service = GeocodingService(reverseGeocode: { coordinate in
+      try await resolver.resolve(coordinate)
+    })
+
+    let city = await service.cityName(for: CLLocationCoordinate2D(latitude: 12.9716, longitude: 77.5946))
+    let callCount = await resolver.callCount()
+
+    XCTAssertEqual(city, "Bengaluru")
+    XCTAssertEqual(callCount, 1)
+  }
+
+  func testCityNameFallsBackToSubAdministrativeArea() async {
+    let resolver = ReverseGeocodeStub(
+      outcomes: [
+        .placemark(
+          GeocodingPlacemark(
+            locality: nil,
+            subAdministrativeArea: "Bangalore Urban",
+            administrativeArea: "Karnataka"
+          )
+        )
+      ]
+    )
+    let service = GeocodingService(reverseGeocode: { coordinate in
+      try await resolver.resolve(coordinate)
+    })
+
+    let city = await service.cityName(for: CLLocationCoordinate2D(latitude: 12.9716, longitude: 77.5946))
+
+    XCTAssertEqual(city, "Bangalore Urban")
+  }
+
+  func testCityNameUsesRoundedCoordinateCache() async {
+    let resolver = ReverseGeocodeStub(
+      outcomes: [
+        .placemark(
+          GeocodingPlacemark(
+            locality: "Mysuru",
+            subAdministrativeArea: nil,
+            administrativeArea: nil
+          )
+        )
+      ]
+    )
+    let service = GeocodingService(reverseGeocode: { coordinate in
+      try await resolver.resolve(coordinate)
+    })
+
+    let first = await service.cityName(for: CLLocationCoordinate2D(latitude: 12.3451, longitude: 77.9871))
+    let second = await service.cityName(for: CLLocationCoordinate2D(latitude: 12.3452, longitude: 77.9872))
+    let callCount = await resolver.callCount()
+
+    XCTAssertEqual(first, "Mysuru")
+    XCTAssertEqual(second, "Mysuru")
+    XCTAssertEqual(callCount, 1)
+  }
+
+  func testCityNameReturnsNilWhenResolverThrows() async {
+    let resolver = ReverseGeocodeStub(outcomes: [.failure])
+    let service = GeocodingService(reverseGeocode: { coordinate in
+      try await resolver.resolve(coordinate)
+    })
+
+    let city = await service.cityName(for: CLLocationCoordinate2D(latitude: 12.9716, longitude: 77.5946))
+    let callCount = await resolver.callCount()
+
+    XCTAssertNil(city)
+    XCTAssertEqual(callCount, 1)
+  }
+
+  func testCityNameEvictsLeastRecentlyUsedEntryWhenCacheIsFull() async {
+    let resolver = ReverseGeocodeStub(
+      outcomes: [
+        .placemark(GeocodingPlacemark(locality: "City One", subAdministrativeArea: nil, administrativeArea: nil)),
+        .placemark(GeocodingPlacemark(locality: "City Two", subAdministrativeArea: nil, administrativeArea: nil)),
+        .placemark(GeocodingPlacemark(locality: "City One Reloaded", subAdministrativeArea: nil, administrativeArea: nil))
+      ]
+    )
+    let service = GeocodingService(maxCacheEntries: 1, reverseGeocode: { coordinate in
+      try await resolver.resolve(coordinate)
+    })
+    let firstCoordinate = CLLocationCoordinate2D(latitude: 12.9716, longitude: 77.5946)
+    let secondCoordinate = CLLocationCoordinate2D(latitude: 13.0827, longitude: 80.2707)
+
+    _ = await service.cityName(for: firstCoordinate)
+    _ = await service.cityName(for: secondCoordinate)
+    let firstAgain = await service.cityName(for: firstCoordinate)
+    let callCount = await resolver.callCount()
+
+    XCTAssertEqual(firstAgain, "City One Reloaded")
+    XCTAssertEqual(callCount, 3)
+  }
+}
+
+private actor ReverseGeocodeStub {
+  enum Outcome: Sendable {
+    case placemark(GeocodingPlacemark?)
+    case failure
+  }
+
+  private var outcomes: [Outcome]
+  private var requests = 0
+
+  init(outcomes: [Outcome]) {
+    self.outcomes = outcomes
+  }
+
+  func resolve(_ coordinate: CLLocationCoordinate2D) async throws -> GeocodingPlacemark? {
+    requests += 1
+    guard !outcomes.isEmpty else { throw StubError.missingOutcome }
+    switch outcomes.removeFirst() {
+    case let .placemark(value):
+      return value
+    case .failure:
+      throw StubError.forcedFailure
+    }
+  }
+
+  func callCount() -> Int {
+    requests
+  }
+}
+
+private enum StubError: Error {
+  case forcedFailure
+  case missingOutcome
+}

--- a/NammaMeterTests/TripStoreTests.swift
+++ b/NammaMeterTests/TripStoreTests.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import Foundation
 import XCTest
 @testable import NammaMeter
@@ -228,4 +229,95 @@ final class TripStoreTests: XCTestCase {
     XCTAssertTrue(store.trips.isEmpty)
   }
 
+  // MARK: - Geocoding Tests
+
+  func testResolveStartLocationUpdatesTripWhenGeocoderReturnsCity() async throws {
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
+    let geocoder = MockGeocodingService(cityName: "Bengaluru")
+    let store = TripStore(fileURL: url, geocoder: geocoder)
+    await TestHelpers.waitForTripStoreLoad(store)
+
+    let trip = Self.makeTripWithPoint()
+    store.add(trip)
+
+    await store.resolveStartLocation(for: trip)
+    let callCount = await geocoder.recordedCallCount()
+
+    XCTAssertEqual(store.trip(for: trip.id)?.startLocationName, "Bengaluru")
+    XCTAssertEqual(callCount, 1)
+  }
+
+  func testResolveStartLocationSkipsLookupWhenNameAlreadyExists() async throws {
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
+    let geocoder = MockGeocodingService(cityName: "Bengaluru")
+    let store = TripStore(fileURL: url, geocoder: geocoder)
+    await TestHelpers.waitForTripStoreLoad(store)
+
+    let trip = Self.makeTripWithPoint(startLocationName: "Mysuru")
+    store.add(trip)
+
+    await store.resolveStartLocation(for: trip)
+    let callCount = await geocoder.recordedCallCount()
+
+    XCTAssertEqual(store.trip(for: trip.id)?.startLocationName, "Mysuru")
+    XCTAssertEqual(callCount, 0)
+  }
+
+  func testResolveStartLocationSkipsLookupWhenTripHasNoPoints() async throws {
+    let url = try TestHelpers.makeTempURL(filename: "trips-test.json")
+    let geocoder = MockGeocodingService(cityName: "Bengaluru")
+    let store = TripStore(fileURL: url, geocoder: geocoder)
+    await TestHelpers.waitForTripStoreLoad(store)
+
+    let trip = TestHelpers.makeTrip(fare: 100)
+    store.add(trip)
+
+    await store.resolveStartLocation(for: trip)
+    let callCount = await geocoder.recordedCallCount()
+
+    XCTAssertNil(store.trip(for: trip.id)?.startLocationName)
+    XCTAssertEqual(callCount, 0)
+  }
+
+  private static func makeTripWithPoint(startLocationName: String? = nil) -> Trip {
+    Trip(
+      id: UUID(),
+      startDate: Date(timeIntervalSince1970: 1_000_000),
+      endDate: Date(timeIntervalSince1970: 1_001_800),
+      distanceMeters: 5_000,
+      duration: 1_800,
+      fare: 100,
+      points: [
+        TripPoint(
+          latitude: 12.9716,
+          longitude: 77.5946,
+          timestamp: Date(timeIntervalSince1970: 1_000_000),
+          speedMetersPerSecond: 0,
+          horizontalAccuracy: 5
+        )
+      ],
+      conditions: .clear,
+      rateSnapshot: RateSnapshot(settings: .bengaluruDefault),
+      multiplier: 1.0,
+      startLocationName: startLocationName
+    )
+  }
+}
+
+private actor MockGeocodingService: GeocodingServiceProtocol {
+  private let cityName: String?
+  private var callCount = 0
+
+  init(cityName: String?) {
+    self.cityName = cityName
+  }
+
+  func cityName(for coordinate: CLLocationCoordinate2D) async -> String? {
+    callCount += 1
+    return cityName
+  }
+
+  func recordedCallCount() -> Int {
+    callCount
+  }
 }


### PR DESCRIPTION
## Summary
- Extracted reverse geocoding from `TripStore` into a dedicated `GeocodingService` actor at `NammaMeter/Location/GeocodingService.swift`.
- Added `GeocodingServiceProtocol` and injected it into `TripStore` so location resolution is protocol-based and mockable.
- Preserved existing behavior (city fallback order, rounded coordinate cache keying, and LRU cache eviction).
- Added focused unit tests for `GeocodingService` (fallback, cache hit behavior, error handling, and eviction).
- Added `TripStore` geocoding tests to validate protocol injection and `resolveStartLocation` behavior.

## Validation
- `xcodebuild -scheme NammaMeter -project NammaMeter.xcodeproj -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -scheme NammaMeter -project NammaMeter.xcodeproj -destination 'generic/platform=iOS Simulator' build-for-testing`
- `xcodebuild test -scheme NammaMeter -project NammaMeter.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:NammaMeterTests/GeocodingServiceTests -only-testing:NammaMeterTests/TripStoreTests`

## Warnings Observed During Build/Test
- Asset catalog notice: `76x76@1x app icons only apply to iPad apps targeting releases of iOS prior to 10.0.`
- AppIntents metadata warning: `Metadata extraction skipped. No AppIntents.framework dependency found.`
- Runtime test warning observed once at test startup: `AttributeGraph: cycle detected through attribute 51808`.

Closes #82
