### PR TITLE
Fix waiting-toggle UI test determinism

### DIFF
--- a/NammaMeter/TestEnvironment.swift
+++ b/NammaMeter/TestEnvironment.swift
@@ -2,10 +2,24 @@ import Foundation
 
 enum TestEnvironment {
   static var isRunningTests: Bool {
-    ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    isRunningTests(
+      environment: ProcessInfo.processInfo.environment,
+      arguments: ProcessInfo.processInfo.arguments
+    )
   }
 
   static var shouldResetState: Bool {
-    ProcessInfo.processInfo.arguments.contains("--reset-state")
+    shouldResetState(arguments: ProcessInfo.processInfo.arguments)
+  }
+
+  static func isRunningTests(
+    environment: [String: String],
+    arguments: [String]
+  ) -> Bool {
+    environment["XCTestConfigurationFilePath"] != nil || arguments.contains("--uitesting")
+  }
+
+  static func shouldResetState(arguments: [String]) -> Bool {
+    arguments.contains("--reset-state")
   }
 }

--- a/NammaMeterTests/TestEnvironmentTests.swift
+++ b/NammaMeterTests/TestEnvironmentTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import NammaMeter
+
+final class TestEnvironmentTests: XCTestCase {
+
+  func testIsRunningTestsTrueWhenXCTestConfigurationPresent() {
+    XCTAssertTrue(
+      TestEnvironment.isRunningTests(
+        environment: ["XCTestConfigurationFilePath": "/tmp/test.xctestconfiguration"],
+        arguments: []
+      )
+    )
+  }
+
+  func testIsRunningTestsTrueWhenUITestingArgumentPresent() {
+    XCTAssertTrue(
+      TestEnvironment.isRunningTests(
+        environment: [:],
+        arguments: ["--uitesting"]
+      )
+    )
+  }
+
+  func testIsRunningTestsFalseWithoutSignals() {
+    XCTAssertFalse(
+      TestEnvironment.isRunningTests(
+        environment: [:],
+        arguments: []
+      )
+    )
+  }
+
+  func testShouldResetStateTrueWhenResetArgumentPresent() {
+    XCTAssertTrue(TestEnvironment.shouldResetState(arguments: ["--reset-state"]))
+  }
+
+  func testShouldResetStateFalseWhenResetArgumentAbsent() {
+    XCTAssertFalse(TestEnvironment.shouldResetState(arguments: ["--uitesting"]))
+  }
+}


### PR DESCRIPTION
## Summary
- Treat `--uitesting` as a test-environment signal in `TestEnvironment.isRunningTests`.
- Keep `TestEnvironment` logic deterministic by adding argument/environment helper functions.
- Add `TestEnvironmentTests` to validate both environment-based and launch-argument-based detection, plus reset-state parsing.

## Why
- UI tests launch the app with `--uitesting`, but `isRunningTests` previously only checked `XCTestConfigurationFilePath`.
- This could allow the app to use real location updates in UI tests, creating nondeterministic waiting-toggle behavior.

## Validation
- `xcodebuild test -scheme NammaMeter -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:NammaMeterTests/TestEnvironmentTests -only-testing:NammaMeterUITests/MeterUITests/testWaitingToggle`

## Warnings Seen During Validation
- `AttributeGraph: cycle detected through attribute 52832` (already tracked in #68)
- `Failed to send CA Event for app launch measurements ...` from `NammaMeterUITests-Runner`

Fixes #98
