### PR TITLE
Isolate hosted unit-test app root from production UI

### DIFF
--- a/NammaMeter/NammaMeterApp.swift
+++ b/NammaMeter/NammaMeterApp.swift
@@ -14,14 +14,25 @@ struct NammaMeterApp: App {
 
   var body: some Scene {
     WindowGroup {
-      ContentView()
-        .environment(container)
-        .modifier(ScreenAwakeSyncModifier(
-          screenAwakeManager: container.screenAwakeManager,
-          settingsStore: container.settingsStore,
-          meterStore: container.meterStore
-        ))
+      if TestEnvironment.isRunningHostedUnitTests {
+        UnitTestHostView()
+      } else {
+        ContentView()
+          .environment(container)
+          .modifier(ScreenAwakeSyncModifier(
+            screenAwakeManager: container.screenAwakeManager,
+            settingsStore: container.settingsStore,
+            meterStore: container.meterStore
+          ))
+      }
     }
+  }
+}
+
+private struct UnitTestHostView: View {
+  var body: some View {
+    Color.clear
+      .ignoresSafeArea()
   }
 }
 

--- a/NammaMeter/TestEnvironment.swift
+++ b/NammaMeter/TestEnvironment.swift
@@ -8,6 +8,13 @@ enum TestEnvironment {
     )
   }
 
+  static var isRunningHostedUnitTests: Bool {
+    isRunningHostedUnitTests(
+      environment: ProcessInfo.processInfo.environment,
+      arguments: ProcessInfo.processInfo.arguments
+    )
+  }
+
   static var shouldResetState: Bool {
     shouldResetState(arguments: ProcessInfo.processInfo.arguments)
   }
@@ -17,6 +24,13 @@ enum TestEnvironment {
     arguments: [String]
   ) -> Bool {
     environment["XCTestConfigurationFilePath"] != nil || arguments.contains("--uitesting")
+  }
+
+  static func isRunningHostedUnitTests(
+    environment: [String: String],
+    arguments: [String]
+  ) -> Bool {
+    environment["XCTestConfigurationFilePath"] != nil && !arguments.contains("--uitesting")
   }
 
   static func shouldResetState(arguments: [String]) -> Bool {

--- a/NammaMeterTests/TestEnvironmentTests.swift
+++ b/NammaMeterTests/TestEnvironmentTests.swift
@@ -30,6 +30,24 @@ final class TestEnvironmentTests: XCTestCase {
     )
   }
 
+  func testIsRunningHostedUnitTestsTrueWhenXCTestConfigurationPresentWithoutUITestArg() {
+    XCTAssertTrue(
+      TestEnvironment.isRunningHostedUnitTests(
+        environment: ["XCTestConfigurationFilePath": "/tmp/test.xctestconfiguration"],
+        arguments: []
+      )
+    )
+  }
+
+  func testIsRunningHostedUnitTestsFalseWhenUITestingArgumentPresent() {
+    XCTAssertFalse(
+      TestEnvironment.isRunningHostedUnitTests(
+        environment: ["XCTestConfigurationFilePath": "/tmp/test.xctestconfiguration"],
+        arguments: ["--uitesting"]
+      )
+    )
+  }
+
   func testShouldResetStateTrueWhenResetArgumentPresent() {
     XCTAssertTrue(TestEnvironment.shouldResetState(arguments: ["--reset-state"]))
   }


### PR DESCRIPTION
## Summary
- Isolate hosted unit-test launch behavior from the production app UI root.
- Route test runs through `TestEnvironment` so tests do not mount the full app root view during hosted execution.
- Add coverage for the new `TestEnvironment` behavior.

## Validation
- Re-ran targeted AttributeGraph warning reproduction tests on the iPhone 17 Pro simulator.
- Observed that the AttributeGraph cycle warning from the targeted scenario is no longer emitted.

## Issues
- Fixes [#68](https://github.com/sridhar-sm/NammaMeter/issues/68)
- Created [#102](https://github.com/sridhar-sm/NammaMeter/issues/102)
- Created [#103](https://github.com/sridhar-sm/NammaMeter/issues/103)
- Created [#104](https://github.com/sridhar-sm/NammaMeter/issues/104)
- Created [#105](https://github.com/sridhar-sm/NammaMeter/issues/105)
- Created [#106](https://github.com/sridhar-sm/NammaMeter/issues/106)
