### PR TITLE
Persist meter display preferences across app restarts

### DIFF
--- a/NammaMeter/MeterView.swift
+++ b/NammaMeter/MeterView.swift
@@ -9,6 +9,7 @@ struct MeterView: View {
   @State private var meterFaceStyle: MeterFaceStyle = .superMeter
   @State private var meterRenderMode: MeterRenderMode = .full
   @State private var digitWheelStyle: DigitWheelStyle = .disk
+  @State private var hasLoadedPreferences = false
 
   var body: some View {
     NavigationStack {
@@ -24,6 +25,16 @@ struct MeterView: View {
           meterStore.requestAuthorization()
         }
         meterStore.refreshTimeBasedConditions()
+        loadMeterPreferences()
+      }
+      .onChange(of: meterFaceStyle) { _, newValue in
+        settingsStore.meterFaceStyle = newValue.rawValue
+      }
+      .onChange(of: meterRenderMode) { _, newValue in
+        settingsStore.meterRenderMode = newValue.rawValue
+      }
+      .onChange(of: digitWheelStyle) { _, newValue in
+        settingsStore.digitWheelStyle = newValue.rawValue
       }
       .withLocationPermissionHandling(coordinator: meterStore.locationPermissionCoordinator)
       .sheet(isPresented: $showMeterSettings) {
@@ -53,6 +64,24 @@ struct MeterView: View {
       digitWheelStyle: $digitWheelStyle,
       isPresented: $showMeterSettings
     )
+  }
+
+  // MARK: - Preferences
+
+  private func loadMeterPreferences() {
+    guard !hasLoadedPreferences else { return }
+    hasLoadedPreferences = true
+
+    // Load persisted preferences from SettingsStore
+    if let style = MeterFaceStyle(rawValue: settingsStore.meterFaceStyle) {
+      meterFaceStyle = style
+    }
+    if let mode = MeterRenderMode(rawValue: settingsStore.meterRenderMode) {
+      meterRenderMode = mode
+    }
+    if let style = DigitWheelStyle(rawValue: settingsStore.digitWheelStyle) {
+      digitWheelStyle = style
+    }
   }
 
 }

--- a/NammaMeter/SettingsStore.swift
+++ b/NammaMeter/SettingsStore.swift
@@ -14,6 +14,25 @@ final class SettingsStore {
     }
   }
 
+  // Meter display preferences - persisted to UserDefaults
+  var meterFaceStyle: String {
+    didSet {
+      UserDefaults.standard.set(meterFaceStyle, forKey: "meterFaceStyle")
+    }
+  }
+
+  var meterRenderMode: String {
+    didSet {
+      UserDefaults.standard.set(meterRenderMode, forKey: "meterRenderMode")
+    }
+  }
+
+  var digitWheelStyle: String {
+    didSet {
+      UserDefaults.standard.set(digitWheelStyle, forKey: "digitWheelStyle")
+    }
+  }
+
   var settings: MeterSettings {
     didSet {
       guard isLoaded, !isSyncingFromProfile else { return }
@@ -70,6 +89,12 @@ final class SettingsStore {
     // Load theme preference from UserDefaults during initialization
     // Falls back to "system" if no preference is stored
     self.themePreference = UserDefaults.standard.string(forKey: "themePreference") ?? "system"
+
+    // Load meter display preferences from UserDefaults
+    // Falls back to default values if not stored
+    self.meterFaceStyle = UserDefaults.standard.string(forKey: "meterFaceStyle") ?? MeterFaceStyle.superMeter.rawValue
+    self.meterRenderMode = UserDefaults.standard.string(forKey: "meterRenderMode") ?? MeterRenderMode.full.rawValue
+    self.digitWheelStyle = UserDefaults.standard.string(forKey: "digitWheelStyle") ?? DigitWheelStyle.disk.rawValue
 
     Task { await load() }
   }

--- a/NammaMeterTests/SettingsStoreTests.swift
+++ b/NammaMeterTests/SettingsStoreTests.swift
@@ -1,0 +1,143 @@
+import Testing
+import Foundation
+@testable import NammaMeter
+
+@MainActor
+@Suite("SettingsStore Tests")
+struct SettingsStoreTests {
+
+  // MARK: - Meter Display Preferences Persistence
+
+  @Test("Meter face style persists to UserDefaults")
+  func meterFaceStylePersistence() async {
+    let tempURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("test-settings-\(UUID().uuidString).json")
+    let defaults = UserDefaults.standard
+
+    // Clear any existing value
+    defaults.removeObject(forKey: "meterFaceStyle")
+
+    let store = SettingsStore(fileURL: tempURL)
+    // Wait for automatic load to complete
+    try? await Task.sleep(for: .milliseconds(100))
+
+    // Verify default value
+    #expect(store.meterFaceStyle == MeterFaceStyle.superMeter.rawValue)
+
+    // Change the value
+    store.meterFaceStyle = MeterFaceStyle.digital.rawValue
+
+    // Verify it was persisted
+    #expect(defaults.string(forKey: "meterFaceStyle") == MeterFaceStyle.digital.rawValue)
+
+    // Cleanup
+    defaults.removeObject(forKey: "meterFaceStyle")
+    try? FileManager.default.removeItem(at: tempURL)
+  }
+
+  @Test("Meter render mode persists to UserDefaults")
+  func meterRenderModePersistence() async {
+    let tempURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("test-settings-\(UUID().uuidString).json")
+    let defaults = UserDefaults.standard
+
+    // Clear any existing value
+    defaults.removeObject(forKey: "meterRenderMode")
+
+    let store = SettingsStore(fileURL: tempURL)
+    // Wait for automatic load to complete
+    try? await Task.sleep(for: .milliseconds(100))
+
+    // Verify default value
+    #expect(store.meterRenderMode == MeterRenderMode.full.rawValue)
+
+    // Change the value
+    store.meterRenderMode = MeterRenderMode.displayOnly.rawValue
+
+    // Verify it was persisted
+    #expect(defaults.string(forKey: "meterRenderMode") == MeterRenderMode.displayOnly.rawValue)
+
+    // Cleanup
+    defaults.removeObject(forKey: "meterRenderMode")
+    try? FileManager.default.removeItem(at: tempURL)
+  }
+
+  @Test("Digit wheel style persists to UserDefaults")
+  func digitWheelStylePersistence() async {
+    let tempURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("test-settings-\(UUID().uuidString).json")
+    let defaults = UserDefaults.standard
+
+    // Clear any existing value
+    defaults.removeObject(forKey: "digitWheelStyle")
+
+    let store = SettingsStore(fileURL: tempURL)
+    // Wait for automatic load to complete
+    try? await Task.sleep(for: .milliseconds(100))
+
+    // Verify default value
+    #expect(store.digitWheelStyle == DigitWheelStyle.disk.rawValue)
+
+    // Change the value
+    store.digitWheelStyle = DigitWheelStyle.drum.rawValue
+
+    // Verify it was persisted
+    #expect(defaults.string(forKey: "digitWheelStyle") == DigitWheelStyle.drum.rawValue)
+
+    // Cleanup
+    defaults.removeObject(forKey: "digitWheelStyle")
+    try? FileManager.default.removeItem(at: tempURL)
+  }
+
+  @Test("Meter preferences restore from UserDefaults on init")
+  func meterPreferencesRestore() async {
+    let tempURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("test-settings-\(UUID().uuidString).json")
+    let defaults = UserDefaults.standard
+
+    // Set values in UserDefaults before creating the store
+    defaults.set(MeterFaceStyle.goldenEagle.rawValue, forKey: "meterFaceStyle")
+    defaults.set(MeterRenderMode.displayOnly.rawValue, forKey: "meterRenderMode")
+    defaults.set(DigitWheelStyle.drum.rawValue, forKey: "digitWheelStyle")
+
+    // Create new store - it should load these values during init
+    let store = SettingsStore(fileURL: tempURL)
+    // Wait for automatic load to complete
+    try? await Task.sleep(for: .milliseconds(100))
+
+    // Verify values were restored
+    #expect(store.meterFaceStyle == MeterFaceStyle.goldenEagle.rawValue)
+    #expect(store.meterRenderMode == MeterRenderMode.displayOnly.rawValue)
+    #expect(store.digitWheelStyle == DigitWheelStyle.drum.rawValue)
+
+    // Cleanup
+    defaults.removeObject(forKey: "meterFaceStyle")
+    defaults.removeObject(forKey: "meterRenderMode")
+    defaults.removeObject(forKey: "digitWheelStyle")
+    try? FileManager.default.removeItem(at: tempURL)
+  }
+
+  @Test("Meter preferences use defaults when not stored")
+  func meterPreferencesDefaults() async {
+    let tempURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("test-settings-\(UUID().uuidString).json")
+    let defaults = UserDefaults.standard
+
+    // Ensure no stored values
+    defaults.removeObject(forKey: "meterFaceStyle")
+    defaults.removeObject(forKey: "meterRenderMode")
+    defaults.removeObject(forKey: "digitWheelStyle")
+
+    let store = SettingsStore(fileURL: tempURL)
+    // Wait for automatic load to complete
+    try? await Task.sleep(for: .milliseconds(100))
+
+    // Verify default values
+    #expect(store.meterFaceStyle == MeterFaceStyle.superMeter.rawValue)
+    #expect(store.meterRenderMode == MeterRenderMode.full.rawValue)
+    #expect(store.digitWheelStyle == DigitWheelStyle.disk.rawValue)
+
+    // Cleanup
+    try? FileManager.default.removeItem(at: tempURL)
+  }
+}


### PR DESCRIPTION
## Summary

Adds persistence for meter display preferences (face style, render mode, digit style) so users don't have to reconfigure their preferred meter appearance on every app launch.

## Changes

### SettingsStore.swift
- Added three new persisted properties to store meter display preferences:
  - `meterFaceStyle: String` - Selected meter face (Super Mechanical, Digital, etc.)
  - `meterRenderMode: String` - Render mode (Full/Display)
  - `digitWheelStyle: String` - Digit style (Drum/Disk)
- Properties use `didSet` observers to automatically persist to `UserDefaults`
- Default values loaded during initialization

### MeterView.swift
- Added `loadMeterPreferences()` function to restore preferences from `SettingsStore` on app launch
- Added `onChange` observers to save preference changes back to `SettingsStore`
- Preferences now sync bidirectionally between UI and persistent storage

### SettingsStoreTests.swift (New)
- Created comprehensive test suite with 5 tests covering:
  - Meter face style persistence
  - Meter render mode persistence  
  - Digit wheel style persistence
  - Preference restoration from UserDefaults
  - Default values when no preferences stored

## Test Results

✅ All 213 tests pass (196 unit + 17 UI tests)
- 5 new tests for meter preference persistence
- No regressions in existing tests

## Issues

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)