### PR TITLE
Fix stale city selection in Settings picker

### DIFF
--- a/NammaMeter/SettingsStore.swift
+++ b/NammaMeter/SettingsStore.swift
@@ -45,7 +45,9 @@ final class SettingsStore {
   }
 
   var selectedCityId: String? {
-    state.selectedCityId
+    didSet {
+      state.selectedCityId = selectedCityId
+    }
   }
 
   var availableCities: [CityFareProfile] {
@@ -85,6 +87,7 @@ final class SettingsStore {
       profiles: [],
       catalogVersionApplied: 0
     )
+    self.selectedCityId = self.state.selectedCityId
 
     // Load theme preference from UserDefaults during initialization
     // Falls back to "system" if no preference is stored
@@ -100,7 +103,7 @@ final class SettingsStore {
   }
 
   func resetToDefaults() {
-    state.selectedCityId = FareCatalog.defaultCityId
+    selectedCityId = FareCatalog.defaultCityId
     if state.profiles.isEmpty {
       state.profiles = FareCatalog.entries.map(\.profile)
       state.catalogVersionApplied = FareCatalog.currentVersion
@@ -113,7 +116,7 @@ final class SettingsStore {
 
   func selectCity(_ cityId: String) {
     guard state.profiles.contains(where: { $0.cityId == cityId }) else { return }
-    state.selectedCityId = cityId
+    selectedCityId = cityId
     syncSettingsFromActiveProfile()
     scheduleSave()
     Log.fare.info("Selected city: \(cityId)")
@@ -121,7 +124,7 @@ final class SettingsStore {
 
   func addCity(_ profile: CityFareProfile) {
     state.profiles.append(profile)
-    state.selectedCityId = profile.cityId
+    selectedCityId = profile.cityId
     syncSettingsFromActiveProfile()
     scheduleSave()
   }
@@ -134,7 +137,7 @@ final class SettingsStore {
   func deleteFareProfile(_ profileId: String) {
     state.profiles.removeAll { $0.id == profileId }
 
-    if let selectedId = state.selectedCityId,
+    if let selectedId = selectedCityId,
        !state.profiles.contains(where: { $0.cityId == selectedId }) {
       fallbackToDefaultCity()
     }
@@ -144,7 +147,7 @@ final class SettingsStore {
   func deleteCity(_ cityId: String) {
     state.profiles.removeAll { $0.cityId == cityId }
 
-    if state.selectedCityId == cityId {
+    if selectedCityId == cityId {
       fallbackToDefaultCity()
     }
     scheduleSave()
@@ -152,12 +155,12 @@ final class SettingsStore {
 
   private func fallbackToDefaultCity() {
     if state.profiles.contains(where: { $0.cityId == FareCatalog.defaultCityId }) {
-      state.selectedCityId = FareCatalog.defaultCityId
+      selectedCityId = FareCatalog.defaultCityId
     } else if let first = state.profiles.first {
-      state.selectedCityId = first.cityId
+      selectedCityId = first.cityId
     } else {
       state.profiles = [FareCatalog.defaultProfile]
-      state.selectedCityId = FareCatalog.defaultCityId
+      selectedCityId = FareCatalog.defaultCityId
     }
     syncSettingsFromActiveProfile()
   }
@@ -224,6 +227,8 @@ final class SettingsStore {
       Log.persistence.info("No existing fare profiles, using catalog defaults")
       didMutate = true
     }
+
+    selectedCityId = state.selectedCityId
 
     // Step 2: Bump schema version if needed
     // Future: Add version-specific migrations here (e.g., if schemaVersion == 1 { migrateV1toV2() })
@@ -352,7 +357,7 @@ final class SettingsStore {
   ///
   /// - Returns: `true` if selection was normalized, `false` if selection is already valid
   private func normalizeSelection() -> Bool {
-    let selectedId = state.selectedCityId
+    let selectedId = selectedCityId
     let hasSelected = selectedId != nil && state.profiles.contains { $0.cityId == selectedId }
     if hasSelected {
       return false
@@ -362,7 +367,7 @@ final class SettingsStore {
     if !state.profiles.contains(where: { $0.cityId == FareCatalog.defaultCityId }) {
       state.profiles.append(FareCatalog.defaultProfile)
     }
-    state.selectedCityId = FareCatalog.defaultCityId
+    selectedCityId = FareCatalog.defaultCityId
     return true
   }
 
@@ -438,7 +443,7 @@ final class SettingsStore {
     )
 
     state.profiles.append(newProfile)
-    state.selectedCityId = cityId
+    selectedCityId = cityId
     scheduleSave()
   }
 
@@ -485,7 +490,7 @@ final class SettingsStore {
   }
 
   private var effectiveCityId: String {
-    state.selectedCityId ?? FareCatalog.defaultCityId
+    selectedCityId ?? FareCatalog.defaultCityId
   }
 
   private func activeProfile(for cityId: String, on date: Date) -> CityFareProfile? {

--- a/NammaMeterTests/FareProfileTests.swift
+++ b/NammaMeterTests/FareProfileTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import XCTest
 @testable import NammaMeter
 
@@ -127,6 +128,26 @@ final class FareProfileTests: XCTestCase {
     XCTAssertEqual(store.selectedCityId, "mandya")
     XCTAssertNotEqual(store.settings.baseFare, bengaluruBaseFare)
     XCTAssertEqual(store.settings.baseFare, 30)
+  }
+
+  func testCitySelectionNotifiesObservers() async throws {
+    let url = try TestHelpers.makeTempURL(filename: "fare-profiles.json")
+    let store = SettingsStore(fileURL: url)
+    await TestHelpers.waitForProfiles(store)
+
+    let changeObserved = expectation(description: "city selection should notify observers")
+    changeObserved.assertForOverFulfill = false
+
+    withObservationTracking {
+      _ = store.selectedCityId
+    } onChange: {
+      changeObserved.fulfill()
+    }
+
+    store.selectCity("udupi")
+
+    await fulfillment(of: [changeObserved], timeout: 1.0)
+    XCTAssertEqual(store.selectedCityId, "udupi")
   }
 
   func testAvailableCitiesReturnsLatestProfiles() async throws {


### PR DESCRIPTION
## Summary
Fix stale city selection display in Settings so the picker reflects the newly selected city immediately.

## Problem
Selecting a non-default city updates fare behavior correctly, but Settings UI can continue to show Bengaluru as selected.

## Root Cause
`selectedCityId` was effectively read from internal state that did not reliably trigger observation updates for the Settings picker binding.

## Changes
- Make `selectedCityId` an observed surface on `SettingsStore` and sync it back into persisted internal state via `didSet`.
- Route city-selection mutations through `selectedCityId` so UI observation is triggered consistently.
- Keep fallback and normalization flows using the same selection path.
- Add a test that verifies city selection emits observation change notifications.

## Tests
- Added `testCitySelectionNotifiesObservers` in `NammaMeterTests/FareProfileTests.swift`.
- Ran full test suite on iPhone 17 Pro Max.
- UI tests passed.
- Snapshot tests failed with baseline mismatches in `MeterSnapshotTests` on iPhone 17 Pro Max (9 failures).

## Issue
Fixes #126
