### PR TITLE
Fix Golden Eagle forHire fare/distance LED text

### DIFF
--- a/NammaMeter/GoldenEagleMeterView.swift
+++ b/NammaMeter/GoldenEagleMeterView.swift
@@ -222,7 +222,7 @@ struct GoldenEagleFareRow: View {
   var body: some View {
     GoldenEagleDigitField(width: width, height: height, widthFactor: 3.5) { digitHeight in
       if tripState == .forHire {
-        GoldenEagleBlankFareDisplay(digitHeight: digitHeight, colorScheme: ledScheme)
+        GoldenEagleForHireFareDisplay(digitHeight: digitHeight, colorScheme: ledScheme)
       } else {
         FareDigitsDisplay(fare: fare, digitHeight: digitHeight, colorScheme: ledScheme)
       }
@@ -274,28 +274,37 @@ struct GoldenEagleWaitRow: View {
   }
 }
 
-struct GoldenEagleBlankFareDisplay: View {
+struct GoldenEagleForHireFareDisplay: View {
   let digitHeight: CGFloat
   var colorScheme: LEDColorScheme = .green
 
+  static let forHireValues: [LED7SegmentValue] = [
+    .blank,
+    .character("F"),
+    .character("o"),
+    .character("r"),
+    .blank
+  ]
+
   var body: some View {
-    let blanks = Array(repeating: LED7SegmentValue.blank, count: 3)
-    let paiseBlanks = Array(repeating: LED7SegmentValue.blank, count: 2)
+    let values = Self.forHireValues
 
     return HStack(spacing: digitHeight * 0.12) {
       LEDDigitGroup(
         digitCount: 3,
         height: digitHeight,
         colorScheme: colorScheme,
-        decimalPosition: 2,
-        values: blanks
+        values: Array(values.prefix(3))
       )
+
+      LEDDecimalPoint(isActive: false, colorScheme: colorScheme, size: digitHeight * 0.12)
+        .offset(y: digitHeight * 0.4)
 
       LEDDigitGroup(
         digitCount: 2,
         height: digitHeight,
         colorScheme: colorScheme,
-        values: paiseBlanks
+        values: Array(values.suffix(2))
       )
     }
   }
@@ -305,12 +314,15 @@ struct GoldenEagleHireDistanceDisplay: View {
   let digitHeight: CGFloat
   var colorScheme: LEDColorScheme = .green
 
+  static let forHireValues: [LED7SegmentValue] = [
+    .character("H"),
+    .character("I"),
+    .character("r"),
+    .character("E")
+  ]
+
   var body: some View {
-    let values: [LED7SegmentValue] = [
-      .character("H"),
-      .character("I"),
-      .character("r")
-    ]
+    let values = Self.forHireValues
 
     return HStack(spacing: digitHeight * 0.08) {
       LEDDigitGroup(
@@ -318,14 +330,14 @@ struct GoldenEagleHireDistanceDisplay: View {
         height: digitHeight,
         colorScheme: colorScheme,
         isSmall: true,
-        values: values
+        values: Array(values.prefix(3))
       )
 
       LEDDecimalPoint(isActive: false, colorScheme: colorScheme, size: digitHeight * 0.08)
         .offset(y: digitHeight * 0.35)
 
       LED7SegmentDigit(
-        value: .character("E"),
+        value: values[3],
         height: digitHeight,
         colorScheme: colorScheme,
         isSmall: true

--- a/NammaMeterTests/GoldenEagleMeterViewTests.swift
+++ b/NammaMeterTests/GoldenEagleMeterViewTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import NammaMeter
+
+final class GoldenEagleMeterViewTests: XCTestCase {
+  func testForHireFareDisplayShowsForInMiddleSegments() {
+    XCTAssertEqual(
+      GoldenEagleForHireFareDisplay.forHireValues,
+      [.blank, .character("F"), .character("o"), .character("r"), .blank]
+    )
+  }
+
+  func testForHireDistanceDisplayShowsHire() {
+    XCTAssertEqual(
+      GoldenEagleHireDistanceDisplay.forHireValues,
+      [.character("H"), .character("I"), .character("r"), .character("E")]
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Fix Golden Eagle `forHire` LED mapping to match expected electronic meter behavior.
- Fare panel now shows `For` in the middle three segments.
- Distance panel now shows `Hire`.
- Add focused unit tests for both mappings.

## Changes
- `NammaMeter/GoldenEagleMeterView.swift`
  - Replace `forHire` fare placeholder with explicit `For` segment mapping.
  - Keep distance `forHire` mapping explicit as `Hire`.
- `NammaMeterTests/GoldenEagleMeterViewTests.swift`
  - Add tests for fare `For` mapping and distance `Hire` mapping.

## Validation
- Ran:
  - `xcodebuild test -scheme NammaMeter -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:NammaMeterTests/GoldenEagleMeterViewTests`
- Result:
  - 2 tests passed, 0 failures.
  - No build/test warnings in this run.

Closes #128
