### PR TITLE
Bump application version to 1.1

### DIFF
--- a/NammaMeter.xcodeproj/project.pbxproj
+++ b/NammaMeter.xcodeproj/project.pbxproj
@@ -416,7 +416,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = sridharsm.NammaMeter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -446,7 +446,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = sridharsm.NammaMeter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary

- Bumps `MARKETING_VERSION` from `1.0` to `1.1` in both Debug and Release configurations

## Test plan

- [x] Build succeeds on iPhone 17 Pro Max simulator
- [x] All 17 UI tests pass
- [x] All unit tests pass (361 passed)
- [x] 20 snapshot tests fail due to stale references (pre-existing, tracked in #149)

🤖 Generated with [Claude Code](https://claude.com/claude-code)