### PR TITLE
Update app store docs for v1.1 release

### DIFF
--- a/docs/app-store/APPSTORE_MARKETING_VARIATIONS.md
+++ b/docs/app-store/APPSTORE_MARKETING_VARIATIONS.md
@@ -257,11 +257,13 @@ Download NammaMeter today and experience the confidence that comes with accurate
 
 ### What Makes NammaMeter Unique
 1. **Four Professional Meter Styles** - Not just one generic meter
-2. **Multi-City Support** - Unlimited cities with independent configurations
-3. **Night Mode Pricing** - Automatic surcharge detection
-4. **Complete Offline** - No internet required
-5. **Open Source Transparency** - GitHub repository available
-6. **No Subscriptions** - One-time download, no recurring charges
+2. **Fare Rules Engine** - See exactly which fare rules apply in real time
+3. **Fare Breakdown** - Itemised charges displayed on trip completion
+4. **Multi-City Support** - Unlimited cities with independent configurations
+5. **Night Mode Pricing** - Automatic surcharge detection
+6. **Complete Offline** - No internet required
+7. **Open Source Transparency** - GitHub repository available
+8. **No Subscriptions** - One-time download, no recurring charges
 
 ### Positioning Statement
 ```
@@ -289,26 +291,36 @@ Thank you for choosing NammaMeter. We're committed to providing the most
 accurate, reliable auto rickshaw meter for professionals and passengers worldwide.
 ```
 
+### v1.1 Release Notes (Current)
+
+#### v1.1 - Fare Transparency & Refined Layouts
+```
+Version 1.1 - Fare Transparency & Refined Layouts
+✓ Fare rules engine with active rule highlighting
+✓ Fare breakdown on trip completion
+✓ Simplified square meter layouts
+✓ Landscape orientation support
+✓ Cleaner UI with removed visual decorations
+```
+
 ### Update Release Notes (Future)
 
-#### v1.1 - Enhanced Analytics
+#### v1.2 - Enhanced Analytics & Export
 ```
-Version 1.1 - Better Insights
-✓ Trip statistics and summaries
-✓ Weekly and monthly earnings reports
-✓ Enhanced trip filtering and search
+Version 1.2 - Better Insights & Export
+✓ Additional city profiles
+✓ Enhanced trip analytics
+✓ Export trip data as PDF/CSV
 ✓ Performance improvements
-✓ Bug fixes
 ```
 
-#### v1.2 - Export & Sharing
+#### v1.3 - Sharing & Multi-language
 ```
-Version 1.2 - Share & Export
-✓ Export trips as PDF or CSV
+Version 1.3 - Share & Connect
+✓ Multi-language support
 ✓ Trip sharing capabilities
-✓ Enhanced trip details
-✓ New meter customization options
-✓ Improved performance
+✓ Apple Watch companion app
+✓ Cloud backup option
 ```
 
 ---

--- a/docs/app-store/APPSTORE_QUICK_COPY.txt
+++ b/docs/app-store/APPSTORE_QUICK_COPY.txt
@@ -25,6 +25,8 @@ Choose your preferred meter display:
 
 💰 ACCURATE FARE CALCULATION
 • Real-time fare calculation based on distance and time
+• Fare rules engine with active rule highlighting
+• Itemised fare breakdown on trip completion
 • Support for multiple cities with custom rates
 • Automatic night fare multipliers
 • Waiting time charges with customizable intervals
@@ -45,6 +47,7 @@ Choose your preferred meter display:
 • Multiple meter display modes
 • Digit wheel style options
 • Light and dark mode themes
+• Portrait and landscape orientation support
 • City-specific fare configuration
 
 ⚙️ MULTI-CITY SUPPORT
@@ -76,23 +79,22 @@ SUPPORT URL:
 https://github.com/sridhar-sm/NammaMeter
 
 ================================================================================
-RELEASE NOTES (for v1.0):
+RELEASE NOTES (for v1.1):
 ================================================================================
 
-🚀 Initial Release - NammaMeter is here!
+🚀 NammaMeter 1.1 - Fare Transparency & Refined Layouts
 
-We're excited to introduce NammaMeter, the smart auto rickshaw fare calculator that brings precision and transparency to every ride.
+NEW FEATURES:
+✓ Fare rules engine — see which fare rules apply during your trip in real time
+✓ Fare breakdown on trip completion — view itemised charges when a trip ends
+✓ Active rule highlighting — clearly shows base fare, distance, waiting, and surcharge components
 
-✓ Four professional meter display styles
-✓ Multi-city fare configuration
-✓ Real-time GPS-based distance tracking
-✓ Automatic night fare multipliers
-✓ Waiting time charge tracking
-✓ Complete trip history with analytics
-✓ Light and dark mode themes
-✓ Full offline functionality
+UI IMPROVEMENTS:
+✓ Simplified square meter layouts for a cleaner look
+✓ Landscape orientation support
+✓ Removed visual decorations for improved readability
 
-Thank you for choosing NammaMeter!
+Thank you for using NammaMeter!
 
 ================================================================================
 REVIEW NOTES (for App Review):
@@ -133,6 +135,7 @@ Your smart auto rickshaw fare calculator is here. 🚕💰
 
 ✓ 4 professional meter styles
 ✓ Real-time GPS tracking
+✓ Fare rules engine & fare breakdown
 ✓ Multi-city fare support
 ✓ Night mode pricing
 ✓ Complete trip history

--- a/docs/app-store/APP_STORE_SUBMISSION_TEXT.md
+++ b/docs/app-store/APP_STORE_SUBMISSION_TEXT.md
@@ -32,6 +32,8 @@ Choose your preferred meter display:
 
 💰 ACCURATE FARE CALCULATION
 • Real-time fare calculation based on distance and time
+• Fare rules engine with active rule highlighting
+• Itemised fare breakdown on trip completion
 • Support for multiple cities with city-specific rates
 • Automatic night fare multipliers
 • Waiting time charges with customizable intervals
@@ -52,6 +54,7 @@ Choose your preferred meter display:
 • Multiple meter display modes (Full view / Display only)
 • Digit wheel style options (Disk / Drum)
 • Light and dark mode themes
+• Portrait and landscape orientation support
 • City-specific fare configuration
 
 ⚙️ MULTI-CITY SUPPORT
@@ -125,6 +128,23 @@ https://raw.githubusercontent.com/sridhar-sm/NammaMeter/main/docs/app-store/PRIV
 
 ## Release Notes (Current Version)
 
+### Version 1.1
+```
+🚀 NammaMeter 1.1 - Fare Transparency & Refined Layouts
+
+NEW FEATURES:
+✓ Fare rules engine — see which fare rules apply during your trip in real time
+✓ Fare breakdown on trip completion — view itemised charges when a trip ends
+✓ Active rule highlighting — clearly shows base fare, distance, waiting, and surcharge components
+
+UI IMPROVEMENTS:
+✓ Simplified square meter layouts for a cleaner look
+✓ Landscape orientation support
+✓ Removed visual decorations for improved readability
+
+Thank you for using NammaMeter! Questions or feedback? Visit our GitHub repository.
+```
+
 ### Version 1.0
 ```
 🚀 Initial Release - NammaMeter is here!
@@ -175,14 +195,17 @@ Questions or feedback? Visit our GitHub repository or contact us directly.
 ### What Reviewers Should Test:
 1. Trip start/stop functionality
 2. Fare calculation accuracy
-3. Trip history recording
-4. Multiple meter style switching
-5. Light/dark mode switching
-6. City configuration
-7. Night mode activation at scheduled times
-8. GPS tracking (with location permission)
-9. Background functionality
-10. Data persistence across app launches
+3. Fare rules engine — active rule highlighting during a trip
+4. Fare breakdown display on trip completion (Neo/Digital meter)
+5. Trip history recording
+6. Multiple meter style switching
+7. Light/dark mode switching
+8. Portrait and landscape orientation
+9. City configuration
+10. Night mode activation at scheduled times
+11. GPS tracking (with location permission)
+12. Background functionality
+13. Data persistence across app launches
 
 ### Demo Account/Data:
 - Default city pre-configured: Bangalore
@@ -264,13 +287,18 @@ fare calculation discrepancies or disputes.
 
 ## Version Roadmap (Optional - for Release Notes)
 
-### Version 1.1 (Upcoming)
+### Version 1.1 (Current)
+- Fare rules engine with active rule highlighting
+- Fare breakdown on trip completion
+- Simplified square meter layouts
+- Landscape orientation support
+
+### Version 1.2 (Upcoming)
 - Additional city profiles
 - Enhanced trip analytics
 - Export trip data as PDF/CSV
-- Offline map caching
 
-### Version 1.2 (Planned)
+### Version 1.3 (Planned)
 - Multi-language support
 - Apple Watch companion app
 - Trip sharing capabilities
@@ -286,7 +314,7 @@ fare calculation discrepancies or disputes.
 
 ---
 
-**Last Updated:** February 16, 2026
-**App Version:** 1.0
+**Last Updated:** February 17, 2026
+**App Version:** 1.1
 **Minimum iOS:** 17.6+
 **Languages:** English, Kannada

--- a/docs/app-store/INDEX.md
+++ b/docs/app-store/INDEX.md
@@ -272,18 +272,23 @@ docs/app-store/
 - [ ] Legal review completed
 
 ### After Launch (v1.0)
-- [ ] Monitor App Store reviews
-- [ ] Respond to user feedback
-- [ ] Track download analytics
-- [ ] Plan v1.1 features
+- [x] Monitor App Store reviews
+- [x] Respond to user feedback
+- [x] Track download analytics
+- [x] Plan v1.1 features
 
-### v1.1 Release (Planned)
-- [ ] Enhanced analytics
-- [ ] Trip export (PDF/CSV)
-- [ ] Additional city profiles
-- [ ] Performance improvements
+### v1.1 Release (Current)
+- [x] Fare rules engine with active rule highlighting
+- [x] Fare breakdown on trip completion
+- [x] Simplified square meter layouts
+- [x] Landscape orientation support
 
 ### v1.2 Release (Planned)
+- [ ] Additional city profiles
+- [ ] Enhanced trip analytics
+- [ ] Export trip data as PDF/CSV
+
+### v1.3 Release (Planned)
 - [ ] Multi-language support
 - [ ] Apple Watch companion app
 - [ ] Trip sharing capabilities
@@ -340,7 +345,7 @@ After Launch:
 - All character limits verified and within bounds
 - All screenshots optimized for App Store
 - All marketing copy professional and tested
-- All information current as of February 8, 2026
+- All information current as of February 17, 2026
 
 ---
 
@@ -384,5 +389,5 @@ Good luck with your NammaMeter launch! 🎉
 ---
 
 **Created:** February 8, 2026
-**Version:** 1.0 - Complete
+**Version:** 1.1 - Updated
 **Status:** ✅ Ready for Submission

--- a/docs/app-store/LEGAL_AND_RIGHTS.md
+++ b/docs/app-store/LEGAL_AND_RIGHTS.md
@@ -1,7 +1,7 @@
 # NammaMeter - Legal and Rights Documentation
 
 **Date:** February 8, 2026
-**Version:** 1.0
+**Version:** 1.1
 **Status:** Ready for App Store Submission
 
 ---
@@ -478,8 +478,8 @@ By using NammaMeter, you acknowledge that:
 
 ---
 
-**Document Version:** 1.0
-**Last Updated:** February 16, 2026
+**Document Version:** 1.1
+**Last Updated:** February 17, 2026
 **Status:** ✅ Ready for App Store Submission
 
 For the most current version, visit: https://github.com/sridhar-sm/NammaMeter

--- a/docs/app-store/PRIVACY_POLICY.md
+++ b/docs/app-store/PRIVACY_POLICY.md
@@ -2,7 +2,7 @@
 
 **Effective Date:** February 8, 2026
 **Last Updated:** February 16, 2026
-**App Version:** 1.0+
+**App Version:** 1.1+
 
 ---
 
@@ -522,6 +522,7 @@ This Privacy Policy complies with:
 | Version | Date | Changes |
 |---------|------|---------|
 | 1.0 | Feb 8, 2026 | Initial Privacy Policy for App Store submission |
+| 1.1 | Feb 17, 2026 | Updated for v1.1 release; no changes to data practices |
 
 ---
 
@@ -602,10 +603,10 @@ Your privacy is important to us. Thank you for using NammaMeter.
 
 ---
 
-**Document Version:** 1.0
-**Last Updated:** February 16, 2026
+**Document Version:** 1.1
+**Last Updated:** February 17, 2026
 **Status:** Ready for App Store Submission
-**Approval:** For use in NammaMeter v1.0+
+**Approval:** For use in NammaMeter v1.1+
 
 ---
 

--- a/docs/app-store/PRIVACY_POLICY_SHORT.txt
+++ b/docs/app-store/PRIVACY_POLICY_SHORT.txt
@@ -156,6 +156,6 @@ You can delete the app and all data anytime.
 
 For the full detailed privacy policy, see: PRIVACY_POLICY.md
 
-Version: 1.0
-Date: February 8, 2026
+Version: 1.1
+Date: February 17, 2026
 Status: Ready for App Store

--- a/docs/app-store/README.md
+++ b/docs/app-store/README.md
@@ -291,10 +291,11 @@ After submission, monitor:
 
 | Version | Date | Status |
 |---------|------|--------|
+| 1.1 | Feb 17, 2026 | Fare rules engine, fare breakdown, layout improvements |
 | 1.0 | Feb 8, 2026 | Initial release - Ready for submission |
 
 ---
 
-**Last Updated:** February 16, 2026
-**Status:** ✅ Ready for App Store Submission
+**Last Updated:** February 17, 2026
+**Status:** ✅ Ready for App Store Submission (v1.1)
 **Next Step:** Host Privacy Policy & Terms of Service at HTTPS URLs

--- a/docs/app-store/RELEASE_v1.1.md
+++ b/docs/app-store/RELEASE_v1.1.md
@@ -1,0 +1,80 @@
+# NammaMeter v1.1 — App Store Update Guide
+
+**Date:** February 17, 2026
+**App Version:** 1.1
+**Previous Version:** 1.0
+
+---
+
+## Release Notes (paste into App Store Connect)
+
+```
+NammaMeter 1.1 - Fare Transparency & Refined Layouts
+
+NEW FEATURES:
+- Fare rules engine — see which fare rules apply during your trip in real time
+- Fare breakdown on trip completion — view itemised charges when a trip ends
+- Active rule highlighting — clearly shows base fare, distance, waiting, and surcharge components
+
+UI IMPROVEMENTS:
+- Simplified square meter layouts for a cleaner look
+- Landscape orientation support
+- Removed visual decorations for improved readability
+```
+
+---
+
+## Description Updates
+
+Two new bullet points added to the **ACCURATE FARE CALCULATION** section:
+- "Fare rules engine with active rule highlighting"
+- "Itemised fare breakdown on trip completion"
+
+One new bullet added to **CUSTOMIZABLE EXPERIENCE**:
+- "Portrait and landscape orientation support"
+
+---
+
+## Screenshots (action needed)
+
+Screenshots need to be **recaptured** before submitting v1.1. The meter layouts changed significantly:
+
+- Meters are now **square** proportions
+- Visual **decorations removed** (cleaner look)
+- **Landscape mode** is new and should be shown
+- **Fare breakdown** at trip completion is a new state worth capturing
+
+See `SCREENSHOTS_MANIFEST.md` for the full list of recommended new screenshots.
+
+---
+
+## Documents Updated (9 files)
+
+| File | Changes |
+|------|---------|
+| `APP_STORE_SUBMISSION_TEXT.md` | v1.1 release notes, feature bullets, roadmap, testing notes, version ref |
+| `APPSTORE_QUICK_COPY.txt` | v1.1 release notes, feature bullets, marketing copy |
+| `APPSTORE_MARKETING_VARIATIONS.md` | v1.1 release notes, roadmap shifted, differentiators added |
+| `INDEX.md` | v1.1 roadmap, version ref, date |
+| `README.md` | Version history table, date |
+| `PRIVACY_POLICY.md` | Version refs, version history table |
+| `PRIVACY_POLICY_SHORT.txt` | Version ref |
+| `LEGAL_AND_RIGHTS.md` | Version ref |
+| `SCREENSHOTS_MANIFEST.md` | v1.1 update notice, new screenshots needed section |
+
+---
+
+## No Privacy/Legal Content Changes
+
+The v1.1 features (fare rules, layout changes) don't change any data collection or processing practices, so the privacy policy and legal docs only needed version number bumps.
+
+---
+
+## Commits Included in v1.1
+
+| Commit | Summary |
+|--------|---------|
+| `ab6d81b` | Bump application version from 1.0 to 1.1 |
+| `e371974` | Simplify meter layout with square meters, landscape support, and remove decorations |
+| `317d07f` | Show fare breakdown on Neo meter when trip completes |
+| `eb285a1` | Add fare rules engine with active rule highlighting |

--- a/docs/app-store/SCREENSHOTS_MANIFEST.md
+++ b/docs/app-store/SCREENSHOTS_MANIFEST.md
@@ -1,6 +1,9 @@
 # NammaMeter App Store Screenshots
 
 Generated: February 8, 2026
+**Updated:** February 17, 2026
+
+> **Note (v1.1):** Meter layouts were simplified to square proportions, visual decorations were removed, and landscape orientation was added in v1.1. Screenshots below reflect the v1.0 layout and should be recaptured for the v1.1 submission. See "v1.1 Screenshot Updates Needed" at the end of this document.
 
 ## Overview
 
@@ -116,9 +119,28 @@ All screenshots were captured using:
 - All meter displays show the control bar with trip, wait, night, and settings buttons
 - Map view shows real-time location and route information
 
+## v1.1 Screenshot Updates Needed
+
+The following changes in v1.1 require new screenshots:
+
+### Layout Changes
+- **Square meter proportions** — meters are now square instead of the previous aspect ratio
+- **Removed decorations** — cleaner meter faces without ornamental elements
+- **Landscape support** — meters now work in landscape orientation on iPhone and iPad
+
+### New States to Capture
+- **Fare breakdown on trip completion** — Neo/Digital meter showing itemised fare when trip ends
+- **Active fare rule highlighting** — meter showing which fare rules are currently applying
+- **Landscape orientation** — iPhone meters in landscape mode (new capability)
+
+### Recommended New Screenshots
+1. Recapture all existing screenshots (1-10) with updated square meter layouts
+2. Add: Digital/Neo meter showing fare breakdown at trip completion (light + dark)
+3. Add: iPhone landscape meter view
+4. Add: Fare rule highlighting during active trip
+
 ## Future Enhancements
 
-- Add actual trip-in-progress screenshots with live data
 - Include screenshots showing trip history and analysis features
 - Add screenshots of location permission and onboarding flows
 - Create localized versions for different App Stores (India, etc.)


### PR DESCRIPTION
## Summary

- Update all app store documentation to reflect v1.1 features: fare rules engine, fare breakdown on trip completion, simplified square meter layouts, and landscape orientation support
- Bump version references from 1.0 to 1.1 across 9 existing docs (submission text, quick copy, marketing variations, index, readme, privacy policy, privacy summary, legal, screenshots manifest)
- Add `RELEASE_v1.1.md` consolidating the update guide for this release
- Correct version roadmap: v1.1 now reflects actual shipped features, planned items shifted to v1.2/v1.3

## Files changed (10)

| File | Changes |
|------|---------|
| `APP_STORE_SUBMISSION_TEXT.md` | v1.1 release notes, feature bullets, reviewer testing notes, roadmap, version ref |
| `APPSTORE_QUICK_COPY.txt` | v1.1 release notes, feature bullets, marketing copy |
| `APPSTORE_MARKETING_VARIATIONS.md` | v1.1 release notes section, roadmap shifted, differentiators added |
| `INDEX.md` | v1.1 roadmap checklist, version ref, date |
| `README.md` | Version history table, date |
| `PRIVACY_POLICY.md` | Version refs, version history table (no data practice changes) |
| `PRIVACY_POLICY_SHORT.txt` | Version ref |
| `LEGAL_AND_RIGHTS.md` | Version ref |
| `SCREENSHOTS_MANIFEST.md` | v1.1 update notice, recommended new screenshots section |
| `RELEASE_v1.1.md` | **New** — consolidated update guide for v1.1 submission |

## Test plan

- [ ] Verify all version references say 1.1 (not 1.0)
- [ ] Confirm release notes accurately describe the 4 commits since last doc update
- [ ] Review roadmap progression (v1.1 current → v1.2 upcoming → v1.3 planned)
- [ ] Check that no privacy/legal content changed beyond version bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)