### PR TITLE
Favorites in TabView + forHire fare rules preview

### DIFF
--- a/NammaMeter/Views/Meter/FareRulesPreviewPage.swift
+++ b/NammaMeter/Views/Meter/FareRulesPreviewPage.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct FareRulesPreviewPage: View {
+  let profile: CityFareProfile
+
+  var body: some View {
+    GeometryReader { geo in
+      let horizontalPadding: CGFloat = 12
+
+      VStack(spacing: 12) {
+        VStack(spacing: 2) {
+          Text(profile.name)
+            .font(FontPresets.Display.small)
+            .lineLimit(1)
+          Text(VehicleTypeCatalog.displayName(for: profile.vehicleType))
+            .font(FontPresets.Body.mini)
+            .lineLimit(1)
+            .foregroundStyle(.secondary)
+        }
+        .foregroundStyle(Theme.ink)
+
+        ScrollView(.vertical, showsIndicators: false) {
+          VStack(alignment: .leading, spacing: 8) {
+            ForEach(rules) { rule in
+              fareRuleRow(rule)
+            }
+          }
+        }
+
+        Spacer(minLength: 0)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+      .padding(.horizontal, horizontalPadding)
+      .padding(.vertical, 12)
+    }
+  }
+
+  private var rules: [FareRule] {
+    FareRuleEvaluator.allRules(from: profile)
+  }
+
+  private func fareRuleRow(_ rule: FareRule) -> some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(rule.label)
+        .font(FontPresets.Display.caption)
+        .foregroundStyle(Theme.ink)
+      Text(rule.description)
+        .font(FontPresets.Body.small)
+        .foregroundStyle(Theme.ink.opacity(0.7))
+        .lineLimit(2)
+        .minimumScaleFactor(0.85)
+    }
+    .padding(.vertical, 6)
+    .padding(.horizontal, 10)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Theme.mango.opacity(0.3))
+    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+  }
+}

--- a/NammaMeter/Views/Meter/MeterPagerView.swift
+++ b/NammaMeter/Views/Meter/MeterPagerView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MeterPagerView: View {
   @Environment(MeterStore.self) private var meterStore
+  @Environment(SettingsStore.self) private var settingsStore
   @Binding var pagerSelection: Int
   var height: CGFloat? = nil
 
@@ -10,25 +11,39 @@ struct MeterPagerView: View {
       TabView(selection: $pagerSelection) {
         mapPage
           .tag(0)
-        tripDetailsPage
-          .tag(1)
-        ForEach(Array(meterStore.whatIfResults.enumerated()), id: \.element.favorite.id) { index, result in
-          meterPageContainer {
-            WhatIfComparisonPage(
-              result: result,
-              primaryFare: meterStore.fare,
-              primaryCurrencyCode: meterStore.activeCurrencyCode
-            )
+
+        if meterStore.tripState == .forHire {
+          ForEach(Array(forHirePages.enumerated()), id: \.element.id) { index, item in
+            meterPageContainer {
+              FareRulesPreviewPage(profile: item.profile)
+            }
+            .tag(1 + index)
           }
-          .tag(2 + index)
+        } else {
+          tripDetailsPage
+            .tag(1)
+          ForEach(Array(meterStore.whatIfResults.enumerated()), id: \.element.favorite.id) { index, result in
+            meterPageContainer {
+              WhatIfComparisonPage(
+                result: result,
+                primaryFare: meterStore.fare,
+                primaryCurrencyCode: meterStore.activeCurrencyCode
+              )
+            }
+            .tag(2 + index)
+          }
         }
       }
       .tabViewStyle(.page(indexDisplayMode: .always))
       .indexViewStyle(.page(backgroundDisplayMode: .always))
       .background(PageSwipeDisabler().allowsHitTesting(false))
-      .onChange(of: meterStore.whatIfResults.count) { _, newCount in
-        let maxPage = 1 + newCount
-        if pagerSelection > maxPage {
+      .onChange(of: pageCount) { _, newCount in
+        if pagerSelection >= newCount {
+          pagerSelection = min(1, newCount - 1)
+        }
+      }
+      .onChange(of: meterStore.tripState) { _, _ in
+        if pagerSelection > 1 {
           pagerSelection = 1
         }
       }
@@ -42,6 +57,31 @@ struct MeterPagerView: View {
     )
     .shadow(color: Theme.pastelShadow(), radius: 12, x: 0, y: 6)
   }
+
+  // MARK: - ForHire Pages
+
+  private var forHirePages: [ForHirePageItem] {
+    var pages: [ForHirePageItem] = []
+    if let profile = settingsStore.activeProfileForCurrentSelection {
+      pages.append(ForHirePageItem(id: "current", profile: profile))
+    }
+    for fav in settingsStore.whatIfFavorites {
+      if let profile = settingsStore.whatIfProfile(for: fav) {
+        pages.append(ForHirePageItem(id: fav.id, profile: profile))
+      }
+    }
+    return pages
+  }
+
+  private var pageCount: Int {
+    if meterStore.tripState == .forHire {
+      return 1 + forHirePages.count
+    } else {
+      return 2 + meterStore.whatIfResults.count
+    }
+  }
+
+  // MARK: - Trip Pages
 
   private var mapPage: some View {
     meterPageContainer {
@@ -109,4 +149,11 @@ struct MeterPagerView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Theme.card.opacity(0.95))
   }
+}
+
+// MARK: - Supporting Types
+
+private struct ForHirePageItem: Identifiable {
+  let id: String
+  let profile: CityFareProfile
 }

--- a/NammaMeterTests/ForHireFareRulesTests.swift
+++ b/NammaMeterTests/ForHireFareRulesTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import NammaMeter
+
+@MainActor
+final class ForHireFareRulesTests: XCTestCase {
+
+  // MARK: - Helpers
+
+  private func makeStore(favorites: [WhatIfFavorite] = []) async throws -> SettingsStore {
+    let url = try TestHelpers.makeTempURL(filename: "forhire-rules.json")
+    let store = SettingsStore(fileURL: url)
+    await TestHelpers.waitForProfiles(store)
+    for fav in favorites {
+      store.addWhatIfFavorite(fav)
+    }
+    return store
+  }
+
+  private var bengaluruProfile: CityFareProfile {
+    FareCatalog.entries.first(where: { $0.profile.cityId == "bengaluru" && $0.profile.vehicleType == VehicleTypeCatalog.autoRickshaw })!.profile
+  }
+
+  // MARK: - ForHire page list computation
+
+  func testForHirePagesIncludesCurrentAndFavorites() async throws {
+    let store = try await makeStore(favorites: [
+      WhatIfFavorite(cityId: "delhi", vehicleType: VehicleTypeCatalog.autoRickshaw),
+      WhatIfFavorite(cityId: "nyc", vehicleType: VehicleTypeCatalog.yellowTaxi)
+    ])
+
+    // Select a city so activeProfileForCurrentSelection is non-nil
+    store.selectCity("bengaluru")
+
+    let currentProfile = store.activeProfileForCurrentSelection
+    XCTAssertNotNil(currentProfile, "Should have a current profile for bengaluru")
+
+    // Build page list: current + 2 favorites
+    var pages: [(id: String, profile: CityFareProfile)] = []
+    if let profile = store.activeProfileForCurrentSelection {
+      pages.append((id: "current", profile: profile))
+    }
+    for fav in store.whatIfFavorites {
+      if let profile = store.whatIfProfile(for: fav) {
+        pages.append((id: fav.id, profile: profile))
+      }
+    }
+
+    XCTAssertEqual(pages.count, 3, "current + 2 favorites")
+    XCTAssertEqual(pages[0].id, "current")
+    XCTAssertEqual(pages[1].id, "delhi:auto-rickshaw")
+    XCTAssertEqual(pages[2].id, "nyc:yellow-taxi")
+  }
+
+  func testForHirePagesSkipsFavoritesWithNoProfile() async throws {
+    let store = try await makeStore(favorites: [
+      WhatIfFavorite(cityId: "nonexistent-city", vehicleType: "unknown-vehicle"),
+      WhatIfFavorite(cityId: "delhi", vehicleType: VehicleTypeCatalog.autoRickshaw)
+    ])
+
+    store.selectCity("bengaluru")
+
+    var pages: [(id: String, profile: CityFareProfile)] = []
+    if let profile = store.activeProfileForCurrentSelection {
+      pages.append((id: "current", profile: profile))
+    }
+    for fav in store.whatIfFavorites {
+      if let profile = store.whatIfProfile(for: fav) {
+        pages.append((id: fav.id, profile: profile))
+      }
+    }
+
+    // nonexistent-city favorite should be skipped
+    XCTAssertEqual(pages.count, 2, "current + 1 valid favorite (invalid skipped)")
+    XCTAssertEqual(pages[0].id, "current")
+    XCTAssertEqual(pages[1].id, "delhi:auto-rickshaw")
+  }
+
+  func testForHirePagesWithNoFavorites() async throws {
+    let store = try await makeStore()
+
+    store.selectCity("bengaluru")
+
+    var pages: [(id: String, profile: CityFareProfile)] = []
+    if let profile = store.activeProfileForCurrentSelection {
+      pages.append((id: "current", profile: profile))
+    }
+    for fav in store.whatIfFavorites {
+      if let profile = store.whatIfProfile(for: fav) {
+        pages.append((id: fav.id, profile: profile))
+      }
+    }
+
+    XCTAssertEqual(pages.count, 1, "Only current profile, no favorites")
+    XCTAssertEqual(pages[0].id, "current")
+  }
+
+  func testPageCountForHireState() async throws {
+    let store = try await makeStore(favorites: [
+      WhatIfFavorite(cityId: "delhi", vehicleType: VehicleTypeCatalog.autoRickshaw),
+      WhatIfFavorite(cityId: "nyc", vehicleType: VehicleTypeCatalog.yellowTaxi)
+    ])
+
+    store.selectCity("bengaluru")
+
+    // forHire page count = 1 (map) + forHirePages.count
+    var forHirePages: [(id: String, profile: CityFareProfile)] = []
+    if let profile = store.activeProfileForCurrentSelection {
+      forHirePages.append((id: "current", profile: profile))
+    }
+    for fav in store.whatIfFavorites {
+      if let profile = store.whatIfProfile(for: fav) {
+        forHirePages.append((id: fav.id, profile: profile))
+      }
+    }
+
+    let pageCount = 1 + forHirePages.count
+    XCTAssertEqual(pageCount, 4, "map + current + 2 favorites")
+  }
+
+  // MARK: - Fare rules preview content
+
+  func testFareRulesPreviewUsesAllRulesFromProfile() {
+    let rules = FareRuleEvaluator.allRules(from: bengaluruProfile)
+
+    XCTAssertFalse(rules.isEmpty, "Bengaluru profile should produce fare rules")
+    XCTAssertTrue(rules.contains { $0.kind == .baseFare }, "Should have base fare rule")
+    XCTAssertTrue(rules.contains { $0.kind == .distanceCharge }, "Should have distance charge rule")
+    XCTAssertTrue(rules.contains { $0.kind == .minimumFare }, "Should have minimum fare rule")
+
+    // Verify each rule has a label and description
+    for rule in rules {
+      XCTAssertFalse(rule.label.isEmpty, "Rule \(rule.id) should have a label")
+      XCTAssertFalse(rule.description.isEmpty, "Rule \(rule.id) should have a description")
+    }
+  }
+
+  func testFareRulesForFavoriteProfile() async throws {
+    let store = try await makeStore(favorites: [
+      WhatIfFavorite(cityId: "nyc", vehicleType: VehicleTypeCatalog.yellowTaxi)
+    ])
+
+    let fav = store.whatIfFavorites[0]
+    let profile = store.whatIfProfile(for: fav)
+    XCTAssertNotNil(profile, "Should resolve NYC yellow taxi profile")
+
+    let rules = FareRuleEvaluator.allRules(from: profile!)
+    XCTAssertTrue(rules.contains { $0.kind == .baseFare })
+    XCTAssertTrue(rules.contains { $0.kind == .speedBasedCharge }, "NYC uses speed-based charging")
+  }
+}


### PR DESCRIPTION
## Summary
- Replace the zero-value trip details page in `forHire` state with fare rule preview pages
- Users can swipe through fare rules for the current city/vehicle selection and each WhatIf favorite
- `forHire` acts as a preview mode: Map → Current Fare Rules → Favorite 1 Rules → Favorite 2 Rules → ...
- Active trip behavior (trip details + WhatIf comparison pages) remains unchanged

## Changes
- **`FareRulesPreviewPage.swift`** (new): Displays fare rules for a `CityFareProfile` using `FareRuleEvaluator.allRules(from:)`, with scrollable rule list
- **`MeterPagerView.swift`** (modified): Conditional page rendering based on `tripState`, bounds checking for page count changes, pager reset on state transitions
- **`ForHireFareRulesTests.swift`** (new): 6 tests covering page computation, invalid favorite handling, page count, and fare rule content

Closes #156

## Test plan
- [x] All 6 new `ForHireFareRulesTests` pass
- [x] All 391 tests pass (16 pre-existing snapshot failures tracked in #149)
- [x] No regressions in `FareRuleEvaluatorTests`, `Phase6FavoritesUITests`, `SettingsStoreTests`
- [x] Manual: launch in Simulator, verify forHire shows fare rules pages for current + favorites
- [x] Manual: start a trip, confirm WhatIf comparison pages still work
- [x] Manual: add/remove favorites, verify pager adjusts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)