### PR TITLE
Extract shared meter context badge overlay

### DIFF
--- a/NammaMeter/BrightDigitalMeterView.swift
+++ b/NammaMeter/BrightDigitalMeterView.swift
@@ -52,16 +52,15 @@ struct BrightDigitalFullMeterPanel: View {
         }
         .frame(width: faceWidth, height: faceHeight)
 
-        if !cityVehicleLabel.isEmpty {
-          MeterCityVehicleLabel(text: cityVehicleLabel, fontSize: bodyHeight * 0.03)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .padding(.top, bodyHeight * 0.02)
-        }
-
-        if tripState == .inProgress && !currentRoadName.isEmpty {
-          MeterCityVehicleLabel(text: currentRoadName, fontSize: bodyHeight * 0.03)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-            .padding(.bottom, bodyHeight * 0.02)
+        if !cityVehicleLabel.isEmpty || (tripState == .inProgress && !currentRoadName.isEmpty) {
+          MeterContextBadges(
+            tripState: tripState,
+            cityVehicleLabel: cityVehicleLabel,
+            currentRoadName: currentRoadName,
+            fontSize: bodyHeight * 0.03,
+            topPadding: bodyHeight * 0.02,
+            bottomPadding: bodyHeight * 0.02
+          )
         }
       }
     }

--- a/NammaMeter/GoldenEagleMeterView.swift
+++ b/NammaMeter/GoldenEagleMeterView.swift
@@ -36,16 +36,15 @@ struct GoldenEagleFullMeterPanel: View {
           Spacer()
         }
 
-        if !cityVehicleLabel.isEmpty {
-          MeterCityVehicleLabel(text: cityVehicleLabel, fontSize: bodyHeight * 0.03)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .padding(.top, bodyHeight * 0.02)
-        }
-
-        if tripState == .inProgress && !currentRoadName.isEmpty {
-          MeterCityVehicleLabel(text: currentRoadName, fontSize: bodyHeight * 0.03)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-            .padding(.bottom, bodyHeight * 0.02)
+        if !cityVehicleLabel.isEmpty || (tripState == .inProgress && !currentRoadName.isEmpty) {
+          MeterContextBadges(
+            tripState: tripState,
+            cityVehicleLabel: cityVehicleLabel,
+            currentRoadName: currentRoadName,
+            fontSize: bodyHeight * 0.03,
+            topPadding: bodyHeight * 0.02,
+            bottomPadding: bodyHeight * 0.02
+          )
         }
       }
     }

--- a/NammaMeter/MeterTypes.swift
+++ b/NammaMeter/MeterTypes.swift
@@ -392,3 +392,26 @@ struct MeterCityVehicleLabel: View {
       .minimumScaleFactor(0.6)
   }
 }
+
+struct MeterContextBadges: View {
+  let tripState: TripMeterState
+  let cityVehicleLabel: String
+  let currentRoadName: String
+  let fontSize: CGFloat
+  let topPadding: CGFloat
+  let bottomPadding: CGFloat
+
+  var body: some View {
+    if !cityVehicleLabel.isEmpty {
+      MeterCityVehicleLabel(text: cityVehicleLabel, fontSize: fontSize)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .padding(.top, topPadding)
+    }
+
+    if tripState == .inProgress && !currentRoadName.isEmpty {
+      MeterCityVehicleLabel(text: currentRoadName, fontSize: fontSize)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .padding(.bottom, bottomPadding)
+    }
+  }
+}

--- a/NammaMeter/SuperElectronicMeterView.swift
+++ b/NammaMeter/SuperElectronicMeterView.swift
@@ -42,16 +42,15 @@ struct SuperElectronicFullMeterPanel: View {
         }
         .padding(.vertical, bodyHeight * 0.06)
 
-        if !cityVehicleLabel.isEmpty {
-          MeterCityVehicleLabel(text: cityVehicleLabel, fontSize: bodyHeight * 0.03)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .padding(.top, bodyHeight * 0.02)
-        }
-
-        if tripState == .inProgress && !currentRoadName.isEmpty {
-          MeterCityVehicleLabel(text: currentRoadName, fontSize: bodyHeight * 0.03)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-            .padding(.bottom, bodyHeight * 0.02)
+        if !cityVehicleLabel.isEmpty || (tripState == .inProgress && !currentRoadName.isEmpty) {
+          MeterContextBadges(
+            tripState: tripState,
+            cityVehicleLabel: cityVehicleLabel,
+            currentRoadName: currentRoadName,
+            fontSize: bodyHeight * 0.03,
+            topPadding: bodyHeight * 0.02,
+            bottomPadding: bodyHeight * 0.02
+          )
         }
       }
     }

--- a/NammaMeter/SuperMechanicalMeterView.swift
+++ b/NammaMeter/SuperMechanicalMeterView.swift
@@ -51,16 +51,15 @@ struct SuperFullMeterPanel: View {
       SuperMeterPlate(bodyWidth: bodyWidth, bodyHeight: bodyHeight, printInk: printInk, metalPanel: metalPanel, metalEdge: metalEdge)
         .offset(y: bodyHeight * 0.25)
 
-      if !cityVehicleLabel.isEmpty {
-        MeterCityVehicleLabel(text: cityVehicleLabel, fontSize: bodyHeight * 0.03)
-          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-          .padding(.top, bodyHeight * 0.02)
-      }
-
-      if tripState == .inProgress && !currentRoadName.isEmpty {
-        MeterCityVehicleLabel(text: currentRoadName, fontSize: bodyHeight * 0.03)
-          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-          .padding(.bottom, bodyHeight * 0.02)
+      if !cityVehicleLabel.isEmpty || (tripState == .inProgress && !currentRoadName.isEmpty) {
+        MeterContextBadges(
+          tripState: tripState,
+          cityVehicleLabel: cityVehicleLabel,
+          currentRoadName: currentRoadName,
+          fontSize: bodyHeight * 0.03,
+          topPadding: bodyHeight * 0.02,
+          bottomPadding: bodyHeight * 0.02
+        )
       }
     }
     .hirePulse(tripState: tripState, pulse: $hirePulse)


### PR DESCRIPTION
## Summary
- Add shared `MeterContextBadges` component in `NammaMeter/MeterTypes.swift` to render meter context badges.
- Replace duplicated top/bottom badge blocks in:
  - `NammaMeter/SuperMechanicalMeterView.swift`
  - `NammaMeter/SuperElectronicMeterView.swift`
  - `NammaMeter/GoldenEagleMeterView.swift`
  - `NammaMeter/BrightDigitalMeterView.swift`
- Preserve existing badge visibility behavior:
  - top label only when `cityVehicleLabel` is non-empty
  - bottom road label only when `tripState == .inProgress` and `currentRoadName` is non-empty

## Validation
### Build
```bash
xcodebuild -scheme NammaMeter -destination 'generic/platform=iOS Simulator' build
```
- Result: `BUILD SUCCEEDED`

### Tests
```bash
xcodebuild test -scheme NammaMeter -destination 'id=F7CF00FB-3709-4697-9AE7-EACBD86D14F7' -only-testing:NammaMeterTests/MeterSnapshotTests
```
- Result: executed 31 tests, 18 failures (snapshot mismatches)
- Tracking: #149

## Warnings Observed
- `appintentsmetadataprocessor`: `Metadata extraction skipped. No AppIntents.framework dependency found.` (tracked by #78)
- Swift concurrency warnings in `NammaMeterWatch Watch App/WatchConnectivityService.swift` (tracked by #103)
- Simulator runtime WC/launch warning noise during tests (tracked by #102, #174)

## Resolves
- Closes #170
