### PR TITLE
Resolve remaining warning noise in tests

### DIFF
--- a/NammaMeter/AppIntentsDependency.swift
+++ b/NammaMeter/AppIntentsDependency.swift
@@ -1,0 +1,7 @@
+#if canImport(AppIntents)
+import AppIntents
+
+// Keeps an explicit AppIntents module dependency so metadata processing does not
+// warn during test builds when no concrete intents are defined yet.
+private let _appIntentsDependencyAnchor: (any AppIntent.Type)? = nil
+#endif

--- a/NammaMeter/BrightDigitalMeterView.swift
+++ b/NammaMeter/BrightDigitalMeterView.swift
@@ -52,16 +52,15 @@ struct BrightDigitalFullMeterPanel: View {
         }
         .frame(width: faceWidth, height: faceHeight)
 
-        if !cityVehicleLabel.isEmpty {
-          MeterCityVehicleLabel(text: cityVehicleLabel, fontSize: bodyHeight * 0.03)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .padding(.top, bodyHeight * 0.02)
-        }
-
-        if tripState == .inProgress && !currentRoadName.isEmpty {
-          MeterCityVehicleLabel(text: currentRoadName, fontSize: bodyHeight * 0.03)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-            .padding(.bottom, bodyHeight * 0.02)
+        if !cityVehicleLabel.isEmpty || (tripState == .inProgress && !currentRoadName.isEmpty) {
+          MeterContextBadges(
+            tripState: tripState,
+            cityVehicleLabel: cityVehicleLabel,
+            currentRoadName: currentRoadName,
+            fontSize: bodyHeight * 0.03,
+            topPadding: bodyHeight * 0.02,
+            bottomPadding: bodyHeight * 0.02
+          )
         }
       }
     }

--- a/NammaMeter/Connectivity/PhoneConnectivityService.swift
+++ b/NammaMeter/Connectivity/PhoneConnectivityService.swift
@@ -9,6 +9,7 @@ private let logger = Logger(subsystem: "sridharsm.NammaMeter", category: "PhoneC
 @Observable
 final class PhoneConnectivityService: NSObject {
 
+  private let watchConnectivityEnabled: Bool
   private(set) var isWatchReachable = false
   private var lastTripUpdateSent: Date = .distantPast
   private let throttleInterval: TimeInterval = 2.0
@@ -27,7 +28,12 @@ final class PhoneConnectivityService: NSObject {
   private var tripStore: TripStore?
 
   override init() {
+    watchConnectivityEnabled = !TestEnvironment.isRunningTests
     super.init()
+    guard watchConnectivityEnabled else {
+      logger.info("Skipping WatchConnectivity activation in test environment")
+      return
+    }
     guard WCSession.isSupported() else {
       logger.info("WatchConnectivity not supported on this device")
       return
@@ -46,6 +52,7 @@ final class PhoneConnectivityService: NSObject {
   // MARK: - Send Config
 
   func sendConfig(from settingsStore: SettingsStore) {
+    guard watchConnectivityEnabled else { return }
     guard WCSession.isSupported(), WCSession.default.activationState == .activated else { return }
 
     let cityInfo = settingsStore.activeCityInfo
@@ -94,6 +101,7 @@ final class PhoneConnectivityService: NSObject {
   /// Send trip update to Watch if observable changes exceed display thresholds.
   /// Pass `force: true` for state transitions (start/stop/reset) to bypass throttle and thresholds.
   func sendTripUpdate(from meterStore: MeterStore, settingsStore: SettingsStore, force: Bool = false) {
+    guard watchConnectivityEnabled else { return }
     guard WCSession.isSupported(), WCSession.default.activationState == .activated else { return }
     guard isWatchReachable else { return }
 
@@ -175,6 +183,7 @@ final class PhoneConnectivityService: NSObject {
   // MARK: - Send Completed Trip
 
   func sendCompletedTrip(_ trip: Trip) {
+    guard watchConnectivityEnabled else { return }
     guard WCSession.isSupported(), WCSession.default.activationState == .activated else { return }
 
     let summary = WatchTripSummary(
@@ -323,4 +332,3 @@ extension PhoneConnectivityService: WCSessionDelegate {
     }
   }
 }
-

--- a/NammaMeter/GoldenEagleMeterView.swift
+++ b/NammaMeter/GoldenEagleMeterView.swift
@@ -36,16 +36,15 @@ struct GoldenEagleFullMeterPanel: View {
           Spacer()
         }
 
-        if !cityVehicleLabel.isEmpty {
-          MeterCityVehicleLabel(text: cityVehicleLabel, fontSize: bodyHeight * 0.03)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .padding(.top, bodyHeight * 0.02)
-        }
-
-        if tripState == .inProgress && !currentRoadName.isEmpty {
-          MeterCityVehicleLabel(text: currentRoadName, fontSize: bodyHeight * 0.03)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-            .padding(.bottom, bodyHeight * 0.02)
+        if !cityVehicleLabel.isEmpty || (tripState == .inProgress && !currentRoadName.isEmpty) {
+          MeterContextBadges(
+            tripState: tripState,
+            cityVehicleLabel: cityVehicleLabel,
+            currentRoadName: currentRoadName,
+            fontSize: bodyHeight * 0.03,
+            topPadding: bodyHeight * 0.02,
+            bottomPadding: bodyHeight * 0.02
+          )
         }
       }
     }

--- a/NammaMeter/MeterTypes.swift
+++ b/NammaMeter/MeterTypes.swift
@@ -392,3 +392,26 @@ struct MeterCityVehicleLabel: View {
       .minimumScaleFactor(0.6)
   }
 }
+
+struct MeterContextBadges: View {
+  let tripState: TripMeterState
+  let cityVehicleLabel: String
+  let currentRoadName: String
+  let fontSize: CGFloat
+  let topPadding: CGFloat
+  let bottomPadding: CGFloat
+
+  var body: some View {
+    if !cityVehicleLabel.isEmpty {
+      MeterCityVehicleLabel(text: cityVehicleLabel, fontSize: fontSize)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .padding(.top, topPadding)
+    }
+
+    if tripState == .inProgress && !currentRoadName.isEmpty {
+      MeterCityVehicleLabel(text: currentRoadName, fontSize: fontSize)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .padding(.bottom, bottomPadding)
+    }
+  }
+}

--- a/NammaMeter/SuperElectronicMeterView.swift
+++ b/NammaMeter/SuperElectronicMeterView.swift
@@ -42,16 +42,15 @@ struct SuperElectronicFullMeterPanel: View {
         }
         .padding(.vertical, bodyHeight * 0.06)
 
-        if !cityVehicleLabel.isEmpty {
-          MeterCityVehicleLabel(text: cityVehicleLabel, fontSize: bodyHeight * 0.03)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .padding(.top, bodyHeight * 0.02)
-        }
-
-        if tripState == .inProgress && !currentRoadName.isEmpty {
-          MeterCityVehicleLabel(text: currentRoadName, fontSize: bodyHeight * 0.03)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-            .padding(.bottom, bodyHeight * 0.02)
+        if !cityVehicleLabel.isEmpty || (tripState == .inProgress && !currentRoadName.isEmpty) {
+          MeterContextBadges(
+            tripState: tripState,
+            cityVehicleLabel: cityVehicleLabel,
+            currentRoadName: currentRoadName,
+            fontSize: bodyHeight * 0.03,
+            topPadding: bodyHeight * 0.02,
+            bottomPadding: bodyHeight * 0.02
+          )
         }
       }
     }

--- a/NammaMeter/SuperMechanicalMeterView.swift
+++ b/NammaMeter/SuperMechanicalMeterView.swift
@@ -51,16 +51,15 @@ struct SuperFullMeterPanel: View {
       SuperMeterPlate(bodyWidth: bodyWidth, bodyHeight: bodyHeight, printInk: printInk, metalPanel: metalPanel, metalEdge: metalEdge)
         .offset(y: bodyHeight * 0.25)
 
-      if !cityVehicleLabel.isEmpty {
-        MeterCityVehicleLabel(text: cityVehicleLabel, fontSize: bodyHeight * 0.03)
-          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-          .padding(.top, bodyHeight * 0.02)
-      }
-
-      if tripState == .inProgress && !currentRoadName.isEmpty {
-        MeterCityVehicleLabel(text: currentRoadName, fontSize: bodyHeight * 0.03)
-          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-          .padding(.bottom, bodyHeight * 0.02)
+      if !cityVehicleLabel.isEmpty || (tripState == .inProgress && !currentRoadName.isEmpty) {
+        MeterContextBadges(
+          tripState: tripState,
+          cityVehicleLabel: cityVehicleLabel,
+          currentRoadName: currentRoadName,
+          fontSize: bodyHeight * 0.03,
+          topPadding: bodyHeight * 0.02,
+          bottomPadding: bodyHeight * 0.02
+        )
       }
     }
     .hirePulse(tripState: tripState, pulse: $hirePulse)

--- a/NammaMeterTests/AppIntentsDependency.swift
+++ b/NammaMeterTests/AppIntentsDependency.swift
@@ -1,0 +1,7 @@
+#if canImport(AppIntents)
+import AppIntents
+
+// Keeps an explicit AppIntents module dependency so metadata processing does not
+// warn during test builds when no concrete intents are defined yet.
+private let _appIntentsDependencyAnchor: (any AppIntent.Type)? = nil
+#endif

--- a/NammaMeterTests/GoldenEagleMeterViewTests.swift
+++ b/NammaMeterTests/GoldenEagleMeterViewTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import NammaMeter
 
+@MainActor
 final class GoldenEagleMeterViewTests: XCTestCase {
   func testForHireFareDisplayShowsForInMiddleSegments() {
     XCTAssertEqual(

--- a/NammaMeterTests/MeterStoreTests.swift
+++ b/NammaMeterTests/MeterStoreTests.swift
@@ -889,7 +889,7 @@ private func makePlacemark(
 
 import MapKit
 
-private final class StubPlacemark: CLPlacemark {
+private final class StubPlacemark: CLPlacemark, @unchecked Sendable {
   private let _thoroughfare: String?
   private let _subThoroughfare: String?
   private let _name: String?

--- a/NammaMeterTests/ScreenAwakeManagerTests.swift
+++ b/NammaMeterTests/ScreenAwakeManagerTests.swift
@@ -6,16 +6,20 @@ import UIKit
 final class ScreenAwakeManagerTests: XCTestCase {
   var sut: ScreenAwakeManager!
 
-  override func setUp() {
-    super.setUp()
-    sut = ScreenAwakeManager()
-    UIApplication.shared.isIdleTimerDisabled = false
+  override func setUp() async throws {
+    try await super.setUp()
+    await MainActor.run {
+      sut = ScreenAwakeManager()
+      UIApplication.shared.isIdleTimerDisabled = false
+    }
   }
 
-  override func tearDown() {
-    super.tearDown()
-    UIApplication.shared.isIdleTimerDisabled = false
-    sut = nil
+  override func tearDown() async throws {
+    await MainActor.run {
+      UIApplication.shared.isIdleTimerDisabled = false
+      sut = nil
+    }
+    try await super.tearDown()
   }
 
   func testIdleTimerDisabledWhenEnabledAndInProgressAndAppActive() {

--- a/NammaMeterUITests/AppIntentsDependency.swift
+++ b/NammaMeterUITests/AppIntentsDependency.swift
@@ -1,0 +1,7 @@
+#if canImport(AppIntents)
+import AppIntents
+
+// Keeps an explicit AppIntents module dependency so metadata processing does not
+// warn during test builds when no concrete intents are defined yet.
+private let _appIntentsDependencyAnchor: (any AppIntent.Type)? = nil
+#endif

--- a/NammaMeterWatch Watch App/AppIntentsDependency.swift
+++ b/NammaMeterWatch Watch App/AppIntentsDependency.swift
@@ -1,0 +1,7 @@
+#if canImport(AppIntents)
+import AppIntents
+
+// Keeps an explicit AppIntents module dependency so metadata processing does not
+// warn during test builds when no concrete intents are defined yet.
+private let _appIntentsDependencyAnchor: (any AppIntent.Type)? = nil
+#endif

--- a/NammaMeterWatch Watch App/WatchConnectivityService.swift
+++ b/NammaMeterWatch Watch App/WatchConnectivityService.swift
@@ -88,7 +88,7 @@ final class WatchConnectivityService: NSObject {
 
 extension WatchConnectivityService: WCSessionDelegate {
 
-  nonisolated func session(
+  func session(
     _ session: WCSession,
     activationDidCompleteWith activationState: WCSessionActivationState,
     error: Error?
@@ -98,52 +98,40 @@ extension WatchConnectivityService: WCSessionDelegate {
     } else {
       logger.info("WCSession activated")
     }
-    let reachable = session.isReachable
+    isPhoneReachable = session.isReachable
     let pendingContext = session.receivedApplicationContext
-    Task { @MainActor in
-      self.isPhoneReachable = reachable
-      if !pendingContext.isEmpty {
-        self.processApplicationContext(pendingContext)
-      }
+    if !pendingContext.isEmpty {
+      processApplicationContext(pendingContext)
     }
   }
 
-  nonisolated func sessionReachabilityDidChange(_ session: WCSession) {
-    let reachable = session.isReachable
-    Task { @MainActor in
-      self.isPhoneReachable = reachable
-      logger.info("Phone reachability changed: \(reachable)")
-    }
+  func sessionReachabilityDidChange(_ session: WCSession) {
+    isPhoneReachable = session.isReachable
+    logger.info("Phone reachability changed: \(session.isReachable)")
   }
 
-  nonisolated func session(
+  func session(
     _ session: WCSession,
     didReceiveApplicationContext applicationContext: [String: Any]
   ) {
-    Task { @MainActor in
-      self.processApplicationContext(applicationContext)
-    }
+    processApplicationContext(applicationContext)
   }
 
-  nonisolated func session(
+  func session(
     _ session: WCSession,
     didReceiveMessage message: [String: Any]
   ) {
-    Task { @MainActor in
-      if message[WatchMessageKey.config] != nil {
-        self.processApplicationContext(message)
-      } else {
-        self.processTripUpdate(message)
-      }
+    if message[WatchMessageKey.config] != nil {
+      processApplicationContext(message)
+    } else {
+      processTripUpdate(message)
     }
   }
 
-  nonisolated func session(
+  func session(
     _ session: WCSession,
     didReceiveUserInfo userInfo: [String: Any] = [:]
   ) {
-    Task { @MainActor in
-      self.processTripSummary(userInfo)
-    }
+    processTripSummary(userInfo)
   }
 }


### PR DESCRIPTION
## Summary
- gate `PhoneConnectivityService` activation during tests to suppress WatchConnectivity simulator pairing noise
- remove Swift 6 actor-isolation/data-race warnings in watch connectivity delegate handling
- add explicit `AppIntents` dependency anchors in app/watch/test/UI-test targets to avoid metadata extraction warnings
- fix remaining test-target actor-isolation/sendability warnings in `GoldenEagleMeterViewTests`, `ScreenAwakeManagerTests`, and `MeterStoreTests`
- add a narrow test-log wrapper that filters only the known simulator CA Event launch-metrics line

## Validation
- `xcodebuild test -project NammaMeter.xcodeproj -scheme NammaMeter -destination 'id=F7CF00FB-3709-4697-9AE7-EACBD86D14F7' -only-testing:NammaMeterTests/MeterStoreTests/testFareNeverBelowMinimum -only-testing:NammaMeterTests/MeterStoreTests/testStartTripInitializesState -only-testing:NammaMeterTests/MeterStoreTests/testStopTripCreatesTrip`
  - passed; no `warning: Metadata extraction skipped. No AppIntents.framework dependency found.` lines
- `xcodebuild test -project NammaMeter.xcodeproj -scheme NammaMeter -destination 'id=72133B37-FD09-42E4-8D6E-0A5AE80548A7' -only-testing:NammaMeterTests/Phase5ComparisonTests -only-testing:NammaMeterTests/NeoLCDLayoutLogicTests`
  - passed; no `WatchConnectivityService.swift` concurrency warnings
- `xcodebuild test -scheme NammaMeter -destination 'id=F7CF00FB-3709-4697-9AE7-EACBD86D14F7' -only-testing:NammaMeterTests/MeterSnapshotTests`
  - WC pairing warnings no longer present (`pairingIDs no longer match`, `WCSession is not paired` not found)
  - snapshot diffs remain and are intentionally out of scope here
- `scripts/run-xcodebuild-filtered.sh` suppresses only:
  - `[General] Failed to send CA Event for app launch measurements ...`
  - all other warnings/errors remain visible

## Issue Links
Closes #78
Closes #103
Closes #174
Closes #177
Refs #102
